### PR TITLE
Support for get_schema_names in Dialect

### DIFF
--- a/src/drivers/base.py
+++ b/src/drivers/base.py
@@ -438,8 +438,7 @@ class ClickHouseDialect(default.DefaultDialect):
 
     @reflection.cache
     def get_schema_names(self, connection, **kw):
-        # No support for schemas.
-        return []
+        return [row.name for row in connection.execute('SHOW DATABASES')]
 
     @reflection.cache
     def get_foreign_keys(self, connection, table_name, schema=None, **kw):


### PR DESCRIPTION
**ClickHouseDialect.get_schema_names** was not implemented: its role is just to list the databases.

The implementation already exists in cloudfare sqlalchemy-clickhouse driver so it does make sense to also support it here.