### PR TITLE
Column type to return Enum instead of NullType

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# PyCharm project settings
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -89,4 +89,4 @@ ENV/
 .ropeproject
 
 # PyCharm project settings
-.idea
+.idea/

--- a/clickhouse_sqlalchemy/drivers/base.py
+++ b/clickhouse_sqlalchemy/drivers/base.py
@@ -12,7 +12,7 @@ from .. import types
 from ..util import compat
 
 
-# Column spec
+# Column specifications
 colspecs = {}
 
 
@@ -47,7 +47,7 @@ class ClickHouseIdentifierPreparer(compiler.IdentifierPreparer):
 
 class ClickHouseCompiler(compiler.SQLCompiler):
     def visit_mod_binary(self, binary, operator, **kw):
-        return self.process(binary.left, **kw) + " %% " + \
+        return self.process(binary.left, **kw) + ' %% ' + \
             self.process(binary.right, **kw)
 
     def post_process_text(self, text):
@@ -60,7 +60,7 @@ class ClickHouseCompiler(compiler.SQLCompiler):
     def visit_case(self, clause, **kwargs):
         text = 'CASE '
         if clause.value is not None:
-            text += clause.value._compiler_dispatch(self, **kwargs) + " "
+            text += clause.value._compiler_dispatch(self, **kwargs) + ' '
         for cond, result in clause.whens:
             text += 'WHEN ' + cond._compiler_dispatch(
                 self, **kwargs
@@ -324,11 +324,11 @@ class ClickHouseTypeCompiler(compiler.GenericTypeCompiler):
 
     def visit_array(self, type_, **kw):
         item_type = type_api.to_instance(type_.item_type)
-        return "Array(%s)" % self.process(item_type, **kw)
+        return 'Array(%s)' % self.process(item_type, **kw)
 
     def visit_nullable(self, type_, **kw):
         nested_type = type_api.to_instance(type_.nested_type)
-        return "Nullable(%s)" % self.process(nested_type, **kw)
+        return 'Nullable(%s)' % self.process(nested_type, **kw)
 
     def visit_int8(self, type_, **kw):
         return 'Int8'
@@ -369,9 +369,9 @@ class ClickHouseTypeCompiler(compiler.GenericTypeCompiler):
     def _render_enum(self, db_type, type_, **kw):
         choices = (
             "'%s' = %d" %
-            (x.name.replace("'", "\\'"), x.value) for x in type_.enum_type
+            (x.name.replace("'", r"\'"), x.value) for x in type_.enum_type
         )
-        return "%s(%s)" % (db_type, ', '.join(choices))
+        return '%s(%s)' % (db_type, ', '.join(choices))
 
     def visit_enum8(self, type_, **kw):
         return self._render_enum('Enum8', type_, **kw)
@@ -416,8 +416,8 @@ class ClickHouseDialect(default.DefaultDialect):
 
     construct_arguments = [
         (schema.Table, {
-            "data": [],
-            "cluster": None
+            'data': [],
+            'cluster': None
         })
     ]
 

--- a/clickhouse_sqlalchemy/drivers/base.py
+++ b/clickhouse_sqlalchemy/drivers/base.py
@@ -494,11 +494,7 @@ class ClickHouseDialect(default.DefaultDialect):
                 return sqltypes.NullType
 
             type_enum = enum.Enum('%s_enum' % name, options)
-
-            def partial_type():
-                return coltype(type_enum)
-
-            return partial_type
+            return lambda: coltype(type_enum)
 
         else:
             try:

--- a/clickhouse_sqlalchemy/drivers/base.py
+++ b/clickhouse_sqlalchemy/drivers/base.py
@@ -39,10 +39,6 @@ ischema_names = {
 }
 
 
-# Quotes used when parsing enum options
-enum_option_quotes = ("'",)
-
-
 class ClickHouseIdentifierPreparer(compiler.IdentifierPreparer):
     def _escape_identifier(self, value):
         value = value.replace(self.escape_quote, self.escape_to_quote)
@@ -487,7 +483,7 @@ class ClickHouseDialect(default.DefaultDialect):
 
             options = dict()
             if pos >= 0:
-                options = self._parse_enum_options(
+                options = self._parse_options(
                     spec[pos + 1: spec.rfind(')')]
                 )
             if not options:
@@ -505,7 +501,7 @@ class ClickHouseDialect(default.DefaultDialect):
                 return sqltypes.NullType
 
     @staticmethod
-    def _parse_enum_options(option_string):
+    def _parse_options(option_string):
         options = dict()
         after_name = False
         escaped = False
@@ -522,7 +518,7 @@ class ClickHouseDialect(default.DefaultDialect):
                 if ch in (' ', '='):
                     pass
                 elif ch == ',':
-                    options.setdefault(name, int(value))
+                    options[name] = int(value)
                     after_name = False
                     name = ''
                     value = ''  # Reset before collecting new option
@@ -539,7 +535,7 @@ class ClickHouseDialect(default.DefaultDialect):
                     name += ch
 
             else:
-                if ch in enum_option_quotes:
+                if ch == "'":
                     quote_character = ch
 
         if after_name:

--- a/clickhouse_sqlalchemy/drivers/base.py
+++ b/clickhouse_sqlalchemy/drivers/base.py
@@ -427,11 +427,11 @@ class ClickHouseDialect(default.DefaultDialect):
             columns.append(self._get_column_info(name, format_type))
         return columns
 
-    def _get_col_type(self, name, spec):
+    def _get_column_type(self, name, spec):
         if spec.startswith('Array'):
             inner = spec[6:-1]
             coltype = self.ischema_names['_array']
-            return coltype(self._get_col_type(name, inner))
+            return coltype(self._get_column_type(name, inner))
 
         elif spec.startswith('FixedString'):
             length = int(spec[12:-1])
@@ -440,7 +440,7 @@ class ClickHouseDialect(default.DefaultDialect):
         elif spec.startswith('Nullable'):
             inner = spec[9:-1]
             coltype = self.ischema_names['_nullable']
-            return coltype(self._get_col_type(name, inner))
+            return coltype(self._get_column_type(name, inner))
 
         else:
             try:
@@ -453,7 +453,7 @@ class ClickHouseDialect(default.DefaultDialect):
     def _get_column_info(self, name, format_type):
         return {
             'name': name,
-            'type': self._get_col_type(name, format_type),
+            'type': self._get_column_type(name, format_type),
             'nullable': True,
             'default': None,
         }

--- a/clickhouse_sqlalchemy/drivers/base.py
+++ b/clickhouse_sqlalchemy/drivers/base.py
@@ -185,7 +185,7 @@ class ClickHouseCompiler(compiler.SQLCompiler):
             else:
                 text += ', '.join(
                     [f._compiler_dispatch(self, asfrom=True, **kwargs)
-                    for f in froms]
+                     for f in froms]
                 )
         else:
             text += self.default_from()
@@ -487,7 +487,9 @@ class ClickHouseDialect(default.DefaultDialect):
 
             options = dict()
             if pos >= 0:
-                options = self._parse_enum_options(spec[pos + 1: spec.rfind(')')])
+                options = self._parse_enum_options(
+                    spec[pos + 1: spec.rfind(')')]
+                )
             if not options:
                 return sqltypes.NullType
 
@@ -518,7 +520,7 @@ class ClickHouseDialect(default.DefaultDialect):
         for ch in option_string:
             if escaped:
                 name += ch
-                escaped = False  # accepting escaped character
+                escaped = False  # Accepting escaped character
 
             elif after_name:
                 if ch in (' ', '='):
@@ -527,7 +529,7 @@ class ClickHouseDialect(default.DefaultDialect):
                     options.setdefault(name, int(value))
                     after_name = False
                     name = ''
-                    value = ''  # reset before collecting new option
+                    value = ''  # Reset before collecting new option
                 else:
                     value += ch
 
@@ -536,7 +538,7 @@ class ClickHouseDialect(default.DefaultDialect):
                     escaped = True
                 elif ch == quote_character:
                     quote_character = None
-                    after_name = True  # start collecting option value
+                    after_name = True  # Start collecting option value
                 else:
                     name += ch
 
@@ -545,7 +547,7 @@ class ClickHouseDialect(default.DefaultDialect):
                     quote_character = ch
 
         if after_name:
-            options.setdefault(name, int(value))  # append word after last comma
+            options.setdefault(name, int(value))  # Word after last comma
 
         return options
 

--- a/clickhouse_sqlalchemy/types.py
+++ b/clickhouse_sqlalchemy/types.py
@@ -95,6 +95,9 @@ class Enum8(types.Enum):
     __visit_name__ = 'enum8'
 
     def __init__(self, *enums, **kw):
+        if not enums:
+            enums = kw.get('_enums', ())  # passed as keyword
+
         self.enum_type = enums[0]
         super(Enum8, self).__init__(*enums, **kw)
 

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -49,13 +49,24 @@ class ReflectionTestCase(TypesTestCase):
         self.assertIsInstance(coltype, types.Nullable)
         self.assertEqual(coltype.nested_type, types.Int32)
 
-    def test_enum(self):
+    def test_enum8(self):
         enum_options = {'three': 3, "quoted' ": 9, 'comma, ': 14}
         coltype = self._type_round_trip(
-            types.Enum8(enum.Enum('any_enum', enum_options))
+            types.Enum8(enum.Enum('any8_enum', enum_options))
         )[0]
 
         self.assertIsInstance(coltype, types.Enum8)
+        self.assertEqual(
+            {o.name: o.value for o in coltype.enum_type}, enum_options
+        )
+
+    def test_enum16(self):
+        enum_options = {'first': 1024, 'second': 2048}
+        coltype = self._type_round_trip(
+            types.Enum16(enum.Enum('any16_enum', enum_options))
+        )[0]
+
+        self.assertIsInstance(coltype, types.Enum16)
         self.assertEqual(
             {o.name: o.value for o in coltype.enum_type}, enum_options
         )

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -1,3 +1,5 @@
+import enum
+
 from sqlalchemy import Column, inspect
 
 from clickhouse_sqlalchemy import types, engines, Table
@@ -46,3 +48,14 @@ class ReflectionTestCase(TypesTestCase):
 
         self.assertIsInstance(coltype, types.Nullable)
         self.assertEqual(coltype.nested_type, types.Int32)
+
+    def test_enum(self):
+        enum_options = {'three': 3, "quoted' ": 9, 'comma, ': 14}
+        coltype = self._type_round_trip(
+            types.Enum8(enum.Enum('any_enum', enum_options))
+        )[0]
+
+        self.assertIsInstance(coltype, types.Enum8)
+        self.assertEqual(
+            {o.name: o.value for o in coltype.enum_type}, enum_options
+        )


### PR DESCRIPTION
Currently when using
```
e = sa.create_engine(...)
md = sa.MetaData(bind=e)
md.reflect()
```
warnings are logged due to unrecognized types. This occurs due to `Enum8`/`Enum16` being improperly instantiated, without their options.

And in fact, the `DESCRIBE TABLE` calls returns the following: 
```
DESCRIBE TABLE t1

┌─name────────────────┬─type─────────────────────────────────────────────────────────────────────┬─default_type─┬─default_expression─┐
│ id                  │ UInt64                                                                   │              │                    │
│ t_type              │ Enum8('left' = 1, 'right' = 2)                                           │              │                    │
└─────────────────────┴──────────────────────────────────────────────────────────────────────────┴──────────────┴────────────────────┘
```

And when inspecting the column types, the `NullType` is currently returned:
```
i = inspect(e)
cols = i.get_columns('t1')

# {'name': 'id', 'type': UInt64(), 'nullable': True, 'default': None}
# {'name': 'event_type', 'type': NullType(), 'nullable': True, 'default': None}
```

Examples done using table:
```
# CREATE TABLE t1
# (
#     id Int64,
#     t_type Enum8('left' = 1, 'right' = 2)
# )
```

Changes the code to return function instantiating the `Enum8`/`Enum16` correctly with options provided.