### PR TITLE
add Decimal type support

### DIFF
--- a/clickhouse_sqlalchemy/drivers/base.py
+++ b/clickhouse_sqlalchemy/drivers/base.py
@@ -364,6 +364,9 @@ class ClickHouseTypeCompiler(compiler.GenericTypeCompiler):
     def visit_float64(self, type_, **kw):
         return 'Float64'
 
+    def visit_numeric(self, type_, **kw):
+        return 'Decimal(%s,%s)' % (type_.precision, type_.scale)
+
     def _render_enum(self, db_type, type_, **kw):
         choices = (
             "'%s' = %d" %

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,8 +1,9 @@
 from datetime import datetime
-
-from sqlalchemy import Column
+from decimal import Decimal
+from sqlalchemy import Column, Numeric
 from sqlalchemy.sql.ddl import CreateTable
 from clickhouse_sqlalchemy import types, engines, Table
+from clickhouse_sqlalchemy.exceptions import DatabaseException
 
 from tests.testcase import TypesTestCase
 
@@ -26,3 +27,41 @@ class DateTimeTypeTestCase(TypesTestCase):
             self.compile(CreateTable(self.table)),
             'CREATE TABLE test (x DateTime) ENGINE = Memory'
         )
+
+
+class NumericTypeTestCase(TypesTestCase):
+    table = Table(
+        'test', TypesTestCase.metadata(),
+        Column('x', Numeric(10, 2)),
+        engines.Memory()
+    )
+
+    def test_create_table(self):
+        self.assertEqual(
+            self.compile(CreateTable(self.table)),
+            'CREATE TABLE test (x Decimal(10,2)) ENGINE = Memory'
+        )
+
+    def test_select_insert(self):
+        x = Decimal('123456789.12')
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(), [{'x': x}])
+            self.assertEqual(self.session.query(self.table.c.x).scalar(), x)
+
+    def test_insert_truncate(self):
+        value = Decimal('123.129999')
+        expected = Decimal('123.12')
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(), [{'x': value}])
+            self.assertEqual(self.session.query(self.table.c.x).scalar(),
+                             expected)
+
+    def test_insert_overflow(self):
+        value = Decimal('12345678901234567890.1234567890')
+
+        with self.create_table(self.table):
+            with self.assertRaisesRegex(DatabaseException,
+                                        'Column x: argument out of range$'):
+                self.session.execute(self.table.insert(), [{'x': value}])


### PR DESCRIPTION
ClickHouse has supported Decimal type since 18.12.13 as experimental feature and since 18.14.9 as default feature. In this patch I've added support of Decimal type and simple test-cases that covers overflow and truncation behaviors.