### PR TITLE
fix raw connection execute

### DIFF
--- a/clickhouse_sqlalchemy/drivers/native/connector.py
+++ b/clickhouse_sqlalchemy/drivers/native/connector.py
@@ -110,12 +110,16 @@ class Cursor(object):
 
         return tables
 
-    def _prepare(self, context):
-        execution_options = context.execution_options
+    def _prepare(self, context=None):
+        if context:
+            execution_options = context.execution_options
 
-        external_tables = self.make_external_tables(
-            context.dialect, execution_options
-        )
+            external_tables = self.make_external_tables(
+                context.dialect, execution_options
+            )
+        else:
+            execution_options = {}
+            external_tables = None
 
         transport = self._connection.transport
         execute = transport.execute

--- a/tests/drivers/native/test_cursor.py
+++ b/tests/drivers/native/test_cursor.py
@@ -1,0 +1,16 @@
+from tests.testcase import NativeSessionTestCase
+
+
+class CursorTestCase(NativeSessionTestCase):
+    def test_execute_without_context(self):
+        raw = self.session.bind.raw_connection()
+        cur = raw.cursor()
+
+        cur.execute("SELECT * FROM system.numbers LIMIT 1")
+        rv = cur.fetchall()
+        assert len(rv) == 1
+
+    def test_execute_with_context(self):
+        rv = self.session.execute("SELECT * FROM system.numbers LIMIT 1")
+
+        assert len(rv.fetchall()) == 1


### PR DESCRIPTION
Following my bug report #39 , here's a simple check on context during execute preparation.

It does fix the raw connection execution and make no changes when a context is set (vast majority of use cases) however it implies that no execution options can be passed when in raw mode.