### PR TITLE
fixed support for `full` parameter in joins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Decimal type.
 - Handling additional column`comment_expression` in `DESCRIBE TABLE` results during reflection (in ClickHouse server >= 18.15).
+- Support for `full` parameter in `.visit_join()`.
 
 ## [0.0.9] - 2019-01-21
 ### Added

--- a/clickhouse_sqlalchemy/drivers/base.py
+++ b/clickhouse_sqlalchemy/drivers/base.py
@@ -150,7 +150,9 @@ class ClickHouseCompiler(compiler.SQLCompiler):
         if join.all:
             join_type += "ALL "
 
-        if join.isouter:
+        if join.full:
+            join_type += "FULL OUTER JOIN "
+        elif join.isouter:
             join_type += "LEFT OUTER JOIN "
         else:
             join_type += "INNER JOIN "

--- a/tests/orm/test_select.py
+++ b/tests/orm/test_select.py
@@ -142,6 +142,15 @@ class JoinTestCase(BaseTestCase):
             "GLOBAL ALL LEFT OUTER JOIN t1 USING x, y"
         )
 
+        query = session.query(t1.c.x, t2.c.x) \
+            .outerjoin(t2, tuple_(t1.c.x, t1.c.y), all=True, full=True)
+
+        self.assertEqual(
+            self.compile(query),
+            "SELECT x AS t0_x, x AS t1_x FROM t0 "
+            "ALL FULL OUTER JOIN t1 USING x, y"
+        )
+
 
 class YieldTest(NativeSessionTestCase):
     def test_yield_per_and_execution_options(self):


### PR DESCRIPTION
The `full` parameter was not checked in `visit_join`, resulting in `LEFT OUTER JOIN` syntax regardless of its value.

Matches standard syntax:
https://github.com/zzzeek/sqlalchemy/blob/master/lib/sqlalchemy/dialects/mysql/base.py#L1367