### PR TITLE
Fix UnicodeDecodeError

### DIFF
--- a/clickhouse_sqlalchemy/drivers/http/utils.py
+++ b/clickhouse_sqlalchemy/drivers/http/utils.py
@@ -2,7 +2,7 @@ import codecs
 
 
 def unescape(value):
-    return codecs.escape_decode(value)[0].decode('utf-8')
+    return codecs.escape_decode(value)[0].decode('utf-8', errors='replace')
 
 
 def parse_tsv(line):

--- a/tests/drivers/http/test_utils.py
+++ b/tests/drivers/http/test_utils.py
@@ -1,13 +1,17 @@
-from clickhouse_sqlalchemy.drivers.http.utils import parse_tsv
+from clickhouse_sqlalchemy.drivers.http.utils import unescape, parse_tsv
 from tests.testcase import BaseTestCase
 
 
 class HttpUtilsTestCase(BaseTestCase):
-    test_values = [b'', b'a\tb\tc']
+    def test_unescape(self):
+        test_values = [b'', b'a', b'\xff']
+        actual = [unescape(t) for t in test_values]
+        assert actual == ['', 'a', '�']        
 
     def test_parse_tsv(self):
+        test_values = [b'', b'a\tb\tc', b'a\tb\t\xff']
         try:
-            for v in self.test_values:
+            for v in test_values:
                 parse_tsv(v)
         except IndexError:
             self.fail('"parse_tsv" raised IndexError exception!')


### PR DESCRIPTION
There are such cases when clickhouse table can contain wrong symbols that couldn't be found in the utf-8 table. This pull request should handle UnicodeDecodeError.