### PR TITLE
Add native IPv4 and IPv6 types support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 env:
+  - VERSION=19.3.5
   - VERSION=18.14.9
 language: python
 python:

--- a/clickhouse_sqlalchemy/drivers/base.py
+++ b/clickhouse_sqlalchemy/drivers/base.py
@@ -33,6 +33,8 @@ ischema_names = {
     'Float32': FLOAT,
     'String': types.String,
     'UUID': types.UUID,
+    'IPv4': types.IPv4,
+    'IPv6': types.IPv6,
     'FixedString': types.String,
     'Enum8': types.Enum8,
     'Enum16': types.Enum16,
@@ -441,6 +443,12 @@ class ClickHouseTypeCompiler(compiler.GenericTypeCompiler):
 
     def visit_uuid(self, type_, **kw):
         return 'UUID'
+
+    def visit_ipv4(self, type_, **kw):
+        return 'IPv4'
+
+    def visit_ipv6(self, type_, **kw):
+        return 'IPv6'
 
 
 class ClickHouseExecutionContextBase(default.DefaultExecutionContext):

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,21 @@
 import os
 import re
+import sys
 from codecs import open
 
 from setuptools import setup, find_packages
 
 here = os.path.abspath(os.path.dirname(__file__))
+
+PY34 = sys.version_info[0:2] >= (3, 4)
+
+install_requires = [
+        'sqlalchemy>=1.2',
+        'requests',
+        'clickhouse_driver>=0.0.19'
+    ]
+if not PY34:
+    install_requires.append('ipaddress')
 
 with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
@@ -85,12 +96,7 @@ setup(
 
     packages=find_packages('.', exclude=["tests*"]),
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
-    install_requires=[
-        'sqlalchemy>=1.2',
-        'requests',
-        'clickhouse_driver>=0.0.14'
-    ],
-
+    install_requires=install_requires,
     # Registering `clickhouse` as dialect.
     entry_points={
         'sqlalchemy.dialects': dialects

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,11 +1,17 @@
+from __future__ import unicode_literals
+
 from datetime import datetime
 from decimal import Decimal
-from sqlalchemy import Column, Numeric
+from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network
+
+from sqlalchemy import Column, Numeric, and_
 from sqlalchemy.sql.ddl import CreateTable
+
 from clickhouse_sqlalchemy import types, engines, Table
 from clickhouse_sqlalchemy.exceptions import DatabaseException
 
 from tests.testcase import TypesTestCase
+from tests.util import require_server_version
 
 
 class DateTimeTypeTestCase(TypesTestCase):
@@ -78,3 +84,296 @@ class NumericTypeTestCase(TypesTestCase):
             self.compile(CreateTable(table)),
             'CREATE TABLE test (x Decimal(10, 2)) ENGINE = Memory'
         )
+
+
+class IPv4TestCase(TypesTestCase):
+    table = Table(
+        'test', TypesTestCase.metadata(),
+        Column('x', types.IPv4),
+        engines.Memory()
+    )
+
+    @require_server_version(19, 3, 3)
+    def test_create_table(self):
+        self.assertEqual(
+            self.compile(CreateTable(self.table)),
+            'CREATE TABLE test (x IPv4) ENGINE = Memory'
+        )
+
+    @require_server_version(19, 3, 3)
+    def test_select_insert(self):
+        a = IPv4Address('10.0.0.1')
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(), [{'x': a}])
+            self.assertEqual(self.session.query(self.table.c.x).scalar(), a)
+
+    @require_server_version(19, 3, 3)
+    def test_select_insert_string(self):
+        a = '10.0.0.1'
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(), [{'x': a}])
+            self.assertEqual(self.session.query(self.table.c.x).scalar(),
+                             IPv4Address('10.0.0.1'))
+
+    @require_server_version(19, 3, 3)
+    def test_select_where_address(self):
+        a = IPv4Address('10.0.0.1')
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(), [{'x': a}])
+
+            self.assertEqual(self.session.query(self.table.c.x).filter(
+                self.table.c.x == IPv4Address('10.0.0.1')).scalar(), a)
+            self.assertEqual(self.session.query(self.table.c.x).filter(
+                and_(IPv4Address('10.0.0.0') < self.table.c.x,
+                     self.table.c.x < IPv4Address('10.0.0.2'))).scalar(), a)
+
+    @require_server_version(19, 3, 3)
+    def test_select_where_string(self):
+        a = IPv4Address('10.0.0.1')
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(), [{'x': a}])
+
+            self.assertEqual(self.session.query(self.table.c.x).filter(
+                and_('10.0.0.0' < self.table.c.x,
+                     self.table.c.x < '10.0.0.2')).scalar(), a)
+
+    @require_server_version(19, 3, 3)
+    def test_select_in_network(self):
+        ips = [
+            IPv4Address('10.0.0.1'),
+            IPv4Address('10.0.0.2'),
+            IPv4Address('10.0.0.3'),
+            IPv4Address('192.168.0.1')
+        ]
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(),
+                                 [{'x': ip} for ip in ips])
+
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    self.table.c.x.in_(IPv4Network('10.0.0.0/8'))).all(), [
+                    (IPv4Address('10.0.0.1'),),
+                    (IPv4Address('10.0.0.2'),),
+                    (IPv4Address('10.0.0.3'),)
+                ])
+
+    @require_server_version(19, 3, 3)
+    def test_select_in_string(self):
+        ips = [
+            IPv4Address('10.0.0.1'),
+            IPv4Address('10.0.0.2'),
+            IPv4Address('10.0.0.3'),
+            IPv4Address('192.168.0.1')
+        ]
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(),
+                                 [{'x': ip} for ip in ips])
+
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    self.table.c.x.in_('10.0.0.0/8')).all(), [
+                    (IPv4Address('10.0.0.1'),),
+                    (IPv4Address('10.0.0.2'),),
+                    (IPv4Address('10.0.0.3'),)
+                ])
+
+    @require_server_version(19, 3, 3)
+    def test_select_not_in_network(self):
+        ips = [
+            IPv4Address('10.0.0.1'),
+            IPv4Address('10.0.0.2'),
+            IPv4Address('10.0.0.3'),
+            IPv4Address('192.168.0.1')
+        ]
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(),
+                                 [{'x': ip} for ip in ips])
+
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    self.table.c.x.notin_(IPv4Network('10.0.0.0/8'))).all(), [
+                    (IPv4Address('192.168.0.1'),)
+                ])
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    ~self.table.c.x.in_(IPv4Network('10.0.0.0/8'))).all(), [
+                    (IPv4Address('192.168.0.1'),)
+                ])
+
+    @require_server_version(19, 3, 3)
+    def test_select_not_in_string(self):
+        ips = [
+            IPv4Address('10.0.0.1'),
+            IPv4Address('10.0.0.2'),
+            IPv4Address('10.0.0.3'),
+            IPv4Address('192.168.0.1')
+        ]
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(),
+                                 [{'x': ip} for ip in ips])
+
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    self.table.c.x.notin_('10.0.0.0/8')).all(), [
+                    (IPv4Address('192.168.0.1'),)
+                ])
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    ~self.table.c.x.in_('10.0.0.0/8')).all(), [
+                    (IPv4Address('192.168.0.1'),)
+                ])
+
+
+class IPv6TestCase(TypesTestCase):
+    table = Table(
+        'test', TypesTestCase.metadata(),
+        Column('x', types.IPv6),
+        engines.Memory()
+    )
+
+    @require_server_version(19, 3, 3)
+    def test_select_insert(self):
+        a = IPv6Address('79f4:e698:45de:a59b:2765:28e3:8d3a:35ae')
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(), [{'x': a}])
+            self.assertEqual(self.session.query(self.table.c.x).scalar(), a)
+
+    @require_server_version(19, 3, 3)
+    def test_select_insert_string(self):
+        a = '79f4:e698:45de:a59b:2765:28e3:8d3a:35ae'
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(), [{'x': a}])
+            self.assertEqual(self.session.query(self.table.c.x).scalar(),
+                             IPv6Address(a))
+
+    @require_server_version(19, 3, 3)
+    def test_create_table(self):
+        self.assertEqual(
+            self.compile(CreateTable(self.table)),
+            'CREATE TABLE test (x IPv6) ENGINE = Memory'
+        )
+
+    @require_server_version(19, 3, 3)
+    def test_select_where_address(self):
+        a = IPv6Address('42e::2')
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(), [{'x': a}])
+
+            self.assertEqual(self.session.query(self.table.c.x).filter(
+                self.table.c.x == IPv6Address('42e::2')).scalar(), a)
+
+            self.assertEqual(self.session.query(self.table.c.x).filter(
+                and_(IPv6Address('42e::1') < self.table.c.x,
+                     self.table.c.x < IPv6Address('42e::3'))).scalar(), a)
+
+    @require_server_version(19, 3, 3)
+    def test_select_where_string(self):
+        a = IPv6Address('42e::2')
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(), [{'x': a}])
+
+            self.assertEqual(self.session.query(self.table.c.x).filter(
+                and_('42e::1' < self.table.c.x,
+                     self.table.c.x < '42e::3')).scalar(), a)
+
+    @require_server_version(19, 3, 3)
+    def test_select_in_network(self):
+        ips = [
+            IPv6Address('42e::1'),
+            IPv6Address('42e::2'),
+            IPv6Address('42e::3'),
+            IPv6Address('f42e::ffff')
+        ]
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(),
+                                 [{'x': ip} for ip in ips])
+
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    self.table.c.x.in_(IPv6Network('42e::/64'))).all(), [
+                    (IPv6Address('42e::1'),),
+                    (IPv6Address('42e::2'),),
+                    (IPv6Address('42e::3'),)
+                ])
+
+    @require_server_version(19, 3, 3)
+    def test_select_in_string(self):
+        ips = [
+            IPv6Address('42e::1'),
+            IPv6Address('42e::2'),
+            IPv6Address('42e::3'),
+            IPv6Address('f42e::ffff')
+        ]
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(),
+                                 [{'x': ip} for ip in ips])
+
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    self.table.c.x.in_('42e::/64')).all(), [
+                    (IPv6Address('42e::1'),),
+                    (IPv6Address('42e::2'),),
+                    (IPv6Address('42e::3'),)
+                ])
+
+    @require_server_version(19, 3, 3)
+    def test_select_not_in_network(self):
+        ips = [
+            IPv6Address('42e::1'),
+            IPv6Address('42e::2'),
+            IPv6Address('42e::3'),
+            IPv6Address('f42e::ffff')
+        ]
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(),
+                                 [{'x': ip} for ip in ips])
+
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    self.table.c.x.notin_(IPv6Network('42e::/64'))).all(), [
+                    (IPv6Address('f42e::ffff'),)
+                ])
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    ~self.table.c.x.in_(IPv6Network('42e::/64'))).all(), [
+                    (IPv6Address('f42e::ffff'),)
+                ])
+
+    @require_server_version(19, 3, 3)
+    def test_select_not_in_string(self):
+        ips = [
+            IPv6Address('42e::1'),
+            IPv6Address('42e::2'),
+            IPv6Address('42e::3'),
+            IPv6Address('f42e::ffff')
+        ]
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(),
+                                 [{'x': ip} for ip in ips])
+
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    self.table.c.x.notin_('42e::/64')).all(), [
+                    (IPv6Address('f42e::ffff'),)
+                ])
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    ~self.table.c.x.in_('42e::/64')).all(), [
+                    (IPv6Address('f42e::ffff'),)
+                ])

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,25 @@
+from functools import wraps
+
+
+def require_server_version(*version_required):
+    def check(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            self = args[0]
+            conn = self.session.bind.raw_connection()
+
+            i = conn.transport.connection.server_info
+            current = (i.version_major, i.version_minor, i.version_patch)
+            conn.close()
+            if version_required <= current:
+                return f(*args, **kwargs)
+            else:
+                self.skipTest(
+                    'Mininum revision required: {}'.format(
+                        '.'.join(str(x) for x in version_required)
+                    )
+                )
+
+        return wrapper
+
+    return check


### PR DESCRIPTION
This PR adds IPv4 and IPv6 support in sqlalchemy, following the work done in clickhouse-driver.

Note that as no release of clickhouse-driver with IP support is available in pip yet, travis will fail for now. Nonetheless all tests are passing on my computer on python 3.6 and 2.7 (with clickhouse 19.3.3+).

I have also added the require_server_version decorator to be used in tests so IP related tests run only on 19.3.3+

Finally as clickhouse only support basic comparators for IP, I have added the *in* and *not in* operators to generate proper queries, see tests for examples.

