### PR TITLE
joins support

### DIFF
--- a/clickhouse_sqlalchemy/drivers/base.py
+++ b/clickhouse_sqlalchemy/drivers/base.py
@@ -12,9 +12,9 @@ from sqlalchemy.util import (
     to_list,
 )
 
+from clickhouse_sqlalchemy import Table
 from .. import types
 from ..util import compat
-
 
 # Column specifications
 colspecs = {}
@@ -142,36 +142,39 @@ class ClickHouseCompiler(compiler.SQLCompiler):
             return column
 
     def visit_join(self, join, asfrom=False, **kwargs):
-        join_type = " "
+        join_stmt = join.left._compiler_dispatch(self, asfrom=asfrom, **kwargs)
+        join_type = join.type  # need to make variable to prevent leaks in some debuggers
+        if join_type is None:
+            if join.isouter:
+                join_type = 'LEFT OUTER'
+            else:
+                join_type = 'INNER'
+        elif join_type is not None:
+            join_type = join_type.upper()
+            if join.isouter and 'INNER' in join_type:
+                raise exc.CompileError('can\'t compile join with specified INNER type and isouter=True')
+            # isouter=False by default, disable that checking
+            # elif not join.isouter and 'OUTER' in join.type:
+            #     raise exc.CompileError('can\'t compile join with specified OUTER type and isouter=False')
+        if join.full and 'FULL' not in join_type:
+            join_type = 'FULL ' + join_type
 
-        if join.global_:
-            join_type += "GLOBAL "
+        if join.strictness:
+            join_type = join.strictness.upper() + ' ' + join_type
 
-        if join.any:
-            join_type += "ANY "
+        if join.distribution:
+            join_type = join.distribution.upper() + ' ' + join_type
 
-        if join.all:
-            join_type += "ALL "
+        if join_type is not None:
+            join_stmt += ' ' + join_type.upper() + ' JOIN '
 
-        if join.full:
-            join_type += "FULL OUTER JOIN "
-        elif join.isouter:
-            join_type += "LEFT OUTER JOIN "
+        join_stmt += join.right._compiler_dispatch(self, asfrom=asfrom, **kwargs)
+
+        if isinstance(join.onclause, elements.Tuple):
+            join_stmt += ' USING ' + join.onclause._compiler_dispatch(self, **kwargs)
         else:
-            join_type += "INNER JOIN "
-
-        if not isinstance(join.onclause, elements.Tuple):
-            raise exc.CompileError(
-                "Only tuple elements are supported. "
-                "Got: %s" % type(join.onclause)
-            )
-
-        return (
-            join.left._compiler_dispatch(self, asfrom=True, **kwargs) +
-            join_type +
-            join.right._compiler_dispatch(self, asfrom=True, **kwargs) +
-            " USING " + join.onclause._compiler_dispatch(self, **kwargs)
-        )
+            join_stmt += ' ON ' + join.onclause._compiler_dispatch(self, **kwargs)
+        return join_stmt
 
     def visit_array_join(self, array_join, **kwargs):
         return ' \nARRAY JOIN {columns}'.format(
@@ -526,7 +529,7 @@ class ClickHouseDialect(default.DefaultDialect):
     construct_arguments = [
         (schema.Table, {
             'data': [],
-            'cluster': None
+            'cluster': None,
         })
     ]
 
@@ -543,6 +546,11 @@ class ClickHouseDialect(default.DefaultDialect):
             if r.result == 1:
                 return True
         return False
+
+    def reflecttable(self, connection, table, include_columns, exclude_columns, **opts):
+        table.metadata.remove(table)
+        ch_table = Table._make_from_standard(table)
+        super().reflecttable(connection, ch_table, include_columns, exclude_columns, **opts)
 
     @reflection.cache
     def get_columns(self, connection, table_name, schema=None, **kw):
@@ -681,5 +689,5 @@ class ClickHouseDialect(default.DefaultDialect):
         return True
 
     def _get_server_version_info(self, connection):
-        version = connection.scalar('select version()')
+        version = connection.scalar('select version() format TabSeparatedWithNamesAndTypes;')
         return tuple(int(x) for x in version.split('.'))

--- a/clickhouse_sqlalchemy/sql/schema.py
+++ b/clickhouse_sqlalchemy/sql/schema.py
@@ -3,6 +3,10 @@ from sqlalchemy.sql.base import (
     _bind_or_error,
 )
 
+from clickhouse_sqlalchemy.sql.selectable import (
+    Join,
+    Select,
+)
 from . import ddl
 
 
@@ -13,3 +17,24 @@ class Table(TableBase):
         bind._run_visitor(ddl.SchemaDropper,
                           self,
                           checkfirst=checkfirst, if_exists=if_exists)
+
+    def join(self, right, onclause=None, isouter=False, full=False, type=None, strictness=None, distribution=None):
+        return Join(self, right,
+                    onclause=onclause, type=type,
+                    isouter=isouter, full=full,
+                    strictness=strictness, distribution=distribution)
+
+    def select(self, whereclause=None, **params):
+        return Select([self], whereclause, **params)
+
+    @classmethod
+    def _make_from_standard(cls, std_table):
+        ch_table = cls(std_table.name, std_table.metadata)
+        ch_table.schema = std_table.schema
+        ch_table.fullname = std_table.fullname
+        ch_table.implicit_returning = std_table.implicit_returning
+        ch_table.comment = std_table.comment
+        ch_table.info = std_table.info
+        ch_table._prefixes = std_table._prefixes
+        ch_table.dialect_options = std_table.dialect_options
+        return ch_table

--- a/clickhouse_sqlalchemy/sql/selectable.py
+++ b/clickhouse_sqlalchemy/sql/selectable.py
@@ -1,10 +1,28 @@
-from sqlalchemy.sql.selectable import Select as StandardSelect
+from sqlalchemy.sql.selectable import (
+    Select as StandardSelect,
+    Join as StandardJoin,
+)
 
 from clickhouse_sqlalchemy.ext.clauses import ArrayJoin
 from ..ext.clauses import sample_clause
 
 
 __all__ = ('Select', 'select')
+
+
+class Join(StandardJoin):
+
+    def __init__(self, left, right,
+                 onclause=None, isouter=False, full=False,
+                 type=None, strictness=None, distribution=None):
+        if type is not None:
+            type = type.upper()
+        super().__init__(left, right, onclause, isouter=isouter, full=full)
+        self.strictness = None
+        if strictness:
+            self.strictness = strictness
+        self.distribution = distribution
+        self.type = type
 
 
 class Select(StandardSelect):
@@ -24,5 +42,12 @@ class Select(StandardSelect):
         self._array_join = ArrayJoin(*columns)
         return self
 
+    def join(self, right, onclause=None, isouter=False, full=False, type=None, strictness=None, distribution=None):
+        return Join(self, right,
+                    onclause=onclause, type=type,
+                    isouter=isouter, full=full,
+                    strictness=strictness, distribution=distribution)
+
 
 select = Select
+join = Join

--- a/tests/sql/test_schema.py
+++ b/tests/sql/test_schema.py
@@ -1,0 +1,52 @@
+from sqlalchemy.orm import aliased
+
+from clickhouse_sqlalchemy import (
+    types,
+    Table as CHTable,
+    engines,
+)
+from sqlalchemy import (
+    MetaData,
+    Column,
+    text,
+)
+from tests.session import native_session
+from tests.testcase import BaseTestCase
+
+
+class SchemaTestCase(BaseTestCase):
+    def test_reflect(self):
+        """
+        checking, that after call metadata.reflect()
+        we have clickohouse-specific table, which have overridden join methods
+        """
+        unbound_metadata = MetaData(bind=native_session.bind)
+        table = CHTable(
+            'test_reflect',
+            unbound_metadata,
+            Column('x', types.Int32),
+            engines.Log()
+        )
+        table.drop(native_session.bind, if_exists=True)
+        table.create(native_session.bind)
+
+        std_metadata = self.metadata()
+        self.assertFalse(std_metadata.tables)
+        std_metadata.reflect(only=[table.name])
+        table = std_metadata.tables.get(table.name)
+        assert table is not None
+        self.assertTrue(isinstance(table, CHTable))
+
+        query = table.select().join(
+            text('another_table'),
+            table.c.x == 'xxx',
+            type='INNER',
+            strictness='ALL',
+            distribution='GLOBAL'
+        )
+        self.assertEqual(
+            self.compile(query),
+            "SELECT x FROM test_reflect "
+            "GLOBAL ALL INNER JOIN another_table "
+            "ON x = %(x_1)s"
+        )

--- a/tests/sql/test_selectable.py
+++ b/tests/sql/test_selectable.py
@@ -1,18 +1,19 @@
 from sqlalchemy import Column, and_
-
+from sqlalchemy.exc import CompileError
 from clickhouse_sqlalchemy import types, select, Table
 from tests.testcase import BaseTestCase
 
 
 class SelectTestCase(BaseTestCase):
-    def create_table(self, *columns):
+    def create_table(self, table_name=None, *columns):
         metadata = self.metadata()
         columns = columns or [
             Column('x', types.Int32, primary_key=True)
         ]
 
         return Table(
-            't1', metadata,
+            table_name or 't1',
+            metadata,
             *columns
         )
 
@@ -47,6 +48,7 @@ class SelectTestCase(BaseTestCase):
 
     def test_nested_type(self):
         table = self.create_table(
+            't1',
             Column('x', types.Int32, primary_key=True),
             Column('parent', types.Nested(
                 Column('child1', types.Int32),
@@ -71,6 +73,7 @@ class SelectTestCase(BaseTestCase):
 
     def test_nested_array_join(self):
         table = self.create_table(
+            't1',
             Column('x', types.Int32, primary_key=True),
             Column('parent', types.Nested(
                 Column('child1', types.Int32),
@@ -154,4 +157,212 @@ class SelectTestCase(BaseTestCase):
             'SELECT p.child1, p.child2, parent.child1 '
             'FROM t1 '
             'ARRAY JOIN parent AS p'
+        )
+
+    def test_join(self):
+        table_1 = self.create_table('table_1', Column('x', types.UInt32, primary_key=True))
+        table_2 = self.create_table('table_2', Column('y', types.UInt32, primary_key=True))
+
+        def make_statement(type=None,
+                           strictness=None,
+                           distribution=None,
+                           full=False,
+                           isouter=False):
+            join = table_1.join(
+                table_2,
+                table_2.c.y == table_1.c.x,
+                isouter=isouter,
+                full=full,
+                type=type,
+                strictness=strictness,
+                distribution=distribution
+            )
+            return select([table_1.c.x]).select_from(join)
+
+        self.assertEqual(
+            self.compile(make_statement(
+                type='INNER'
+            )),
+            'SELECT x FROM table_1 '
+            'INNER JOIN table_2 ON y = x'
+        )
+
+        self.assertEqual(
+            self.compile(make_statement(
+                type='INNER',
+                strictness='all'
+            )),
+            'SELECT x FROM table_1 '
+            'ALL INNER JOIN table_2 ON y = x'
+        )
+
+        self.assertEqual(
+            self.compile(make_statement(
+                type='INNER',
+                strictness='any'
+            )),
+            'SELECT x FROM table_1 '
+            'ANY INNER JOIN table_2 ON y = x'
+        )
+
+        self.assertEqual(
+            self.compile(make_statement(
+                type='INNER',
+                distribution='global'
+            )),
+            'SELECT x FROM table_1 '
+            'GLOBAL INNER JOIN table_2 ON y = x'
+        )
+
+        self.assertEqual(
+            self.compile(make_statement(
+                type='INNER',
+                distribution='global',
+                strictness='any'
+            )),
+            'SELECT x FROM table_1 '
+            'GLOBAL ANY INNER JOIN table_2 ON y = x'
+        )
+
+        self.assertEqual(
+            self.compile(make_statement(
+                type='INNER',
+                distribution='global',
+                strictness='all'
+            )),
+            'SELECT x FROM table_1 '
+            'GLOBAL ALL INNER JOIN table_2 ON y = x'
+        )
+
+        self.assertEqual(
+            self.compile(make_statement(
+                type='LEFT OUTER',
+                distribution='global',
+                strictness='all')),
+            'SELECT x FROM table_1 '
+            'GLOBAL ALL LEFT OUTER JOIN table_2 ON y = x'
+        )
+
+        self.assertEqual(
+            self.compile(make_statement(
+                type='RIGHT OUTER',
+                distribution='global',
+                strictness='all')),
+            'SELECT x FROM table_1 '
+            'GLOBAL ALL RIGHT OUTER JOIN table_2 ON y = x'
+        )
+
+        self.assertEqual(
+            self.compile(make_statement(
+                type='CROSS',
+                distribution='global',
+                strictness='all')),
+            'SELECT x FROM table_1 '
+            'GLOBAL ALL CROSS JOIN table_2 ON y = x'
+        )
+
+        self.assertEqual(
+            self.compile(make_statement(type='FULL OUTER')),
+            'SELECT x FROM table_1 '
+            'FULL OUTER JOIN table_2 ON y = x'
+        )
+
+        self.assertEqual(
+            self.compile(make_statement(isouter=False,
+                                        full=False)),
+            'SELECT x FROM table_1 '
+            'INNER JOIN table_2 ON y = x'
+        )
+
+        self.assertEqual(
+            self.compile(make_statement(isouter=True,
+                                        full=False)),
+            'SELECT x FROM table_1 '
+            'LEFT OUTER JOIN table_2 ON y = x'
+        )
+
+        self.assertEqual(
+            self.compile(make_statement(isouter=True,
+                                        full=True)),
+            'SELECT x FROM table_1 '
+            'FULL LEFT OUTER JOIN table_2 ON y = x'
+        )
+
+        self.assertEqual(
+            self.compile(make_statement(isouter=False,
+                                        full=True)),
+            'SELECT x FROM table_1 '
+            'FULL INNER JOIN table_2 ON y = x'
+        )
+
+
+
+        self.assertEqual(
+            self.compile(make_statement(
+                isouter=False, full=False,
+                type='INNER'
+            )),
+            'SELECT x FROM table_1 '
+            'INNER JOIN table_2 ON y = x'
+        )
+
+        self.assertEqual(
+            self.compile(make_statement(
+                isouter=False, full=False,
+                type='LEFT OUTER'
+            )),
+            'SELECT x FROM table_1 '
+            'LEFT OUTER JOIN table_2 ON y = x'
+        )
+
+        self.assertEqual(
+            self.compile(make_statement(
+                isouter=False, full=False,
+                type='LEFT', strictness='ALL'
+            )),
+            'SELECT x FROM table_1'
+            ' ALL LEFT JOIN table_2 ON y = x'
+        )
+
+        self.assertEqual(
+            self.compile(make_statement(
+                isouter=False, full=False,
+                type='LEFT', strictness='ANY'
+            )),
+            'SELECT x FROM table_1 '
+            'ANY LEFT JOIN table_2 ON y = x'
+        )
+
+        self.assertEqual(
+            self.compile(make_statement(
+                isouter=False, full=False,
+                type='LEFT', strictness='ANY', distribution='GLOBAL'
+            )),
+            'SELECT x FROM table_1 '
+            'GLOBAL ANY LEFT JOIN table_2 ON y = x'
+        )
+
+        self.assertRaises(
+            CompileError,
+            lambda: self.compile(make_statement(
+                isouter=True, full=False,
+                type='INNER', strictness='ANY', distribution='GLOBAL'
+            )),
+        )
+
+        self.assertEqual(
+            self.compile(make_statement(
+                isouter=True, full=True,
+                type='LEFT OUTER', strictness='ANY', distribution='GLOBAL'
+            )),
+            'SELECT x FROM table_1 GLOBAL '
+            'ANY FULL LEFT OUTER JOIN table_2 ON y = x'
+        )
+
+        self.assertEqual(
+            self.compile(make_statement(
+                isouter=True, full=False,
+                type='CROSS',
+            )),
+            'SELECT x FROM table_1 CROSS JOIN table_2 ON y = x'
         )


### PR DESCRIPTION
OK, here is a join support for standard sqla-core ([issue](https://github.com/xzkostyan/clickhouse-sqlalchemy/issues/35)) and some kind of joins-api refactor.

Example is here: `tests.sql.test_schema.SchemaTestCase#test_reflect`.

The magic is here: `clickhouse_sqlalchemy.drivers.base.ClickHouseDialect#reflecttable`.
I replace table bounded with metadata by the table with another class.

The place that can make you sad is `clickhouse_sqlalchemy.orm.query.Query#join`. But I hope it is not: can't invent another way to make this possible: there are a lot of work inside of `sqlalchemy.orm.query.Query#join` method which should be done, but in the and another class must be used.