### PR TITLE
named arguments should go after positional

### DIFF
--- a/clickhouse_sqlalchemy/engines.py
+++ b/clickhouse_sqlalchemy/engines.py
@@ -178,8 +178,9 @@ class SummingMergeTree(MergeTree):
 class ReplacingMergeTree(MergeTree):
     def __init__(self,
                  *args,
-                 version_col=None,
                  **kwargs):
+
+        version_col = kwargs.pop('version_col', None)
         super(ReplacingMergeTree, self).__init__(
             *args, **kwargs
         )

--- a/clickhouse_sqlalchemy/engines.py
+++ b/clickhouse_sqlalchemy/engines.py
@@ -177,8 +177,8 @@ class SummingMergeTree(MergeTree):
 
 class ReplacingMergeTree(MergeTree):
     def __init__(self,
-                 version_col=None,
                  *args,
+                 version_col=None,
                  **kwargs):
         super(ReplacingMergeTree, self).__init__(
             *args, **kwargs

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -248,9 +248,9 @@ class EnginesDeclarativeTestCase(BaseTestCase):
 
             __table_args__ = (
                 engines.ReplacingMergeTree(
-                    'version',
                     'date',
                     ('date', 'x'),
+                    version_col='version',
                 ),
             )
 
@@ -274,7 +274,8 @@ class EnginesDeclarativeTestCase(BaseTestCase):
             __table_args__ = (
                 engines.ReplicatedReplacingMergeTree(
                     '/table/path', 'name',
-                    'version', 'date', ('date', 'x'),
+                    'date', ('date', 'x'),
+                    version_col='version',
                 ),
             )
 
@@ -299,7 +300,7 @@ class EnginesDeclarativeTestCase(BaseTestCase):
 
             __table_args__ = (
                 engines.ReplacingMergeTree(
-                    version,
+                    version_col=version,
                     partition_by=func.toYYYYMM(date),
                     order_by=(date, x),
                 ),


### PR DESCRIPTION
ReplacingMergeTree param version_col moved after *args, because named arguments should go after positional.

SummingMergeTree have same problem, but I don't know, how it shold work, so I didn't touch it.