### PR TITLE
Add support for `CODEC` column option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,6 +120,10 @@ Both declarative and constructor-style tables support:
         class Rate(Base):
             day = Column(types.Date, primary_key=True)
             value = Column(types.Int32)
+            other_value = Column(
+                types.DateTime,
+                clickhouse_codec=('DoubleDelta', 'ZSTD'),
+            )
 
             __table_args__ = (
                 engines.Memory(),

--- a/clickhouse_sqlalchemy/drivers/base.py
+++ b/clickhouse_sqlalchemy/drivers/base.py
@@ -1,6 +1,8 @@
 import enum
 
-from sqlalchemy import schema, types as sqltypes, exc, util as sa_util
+from sqlalchemy import (
+    schema, Column, types as sqltypes, exc, util as sa_util
+)
 from sqlalchemy.engine import default, reflection
 from sqlalchemy.sql import (
     compiler, expression, type_api, literal_column, elements
@@ -309,6 +311,19 @@ class ClickHouseCompiler(compiler.SQLCompiler):
 
 
 class ClickHouseDDLCompiler(compiler.DDLCompiler):
+    def get_column_specification(self, column, **kw):
+        column_spec = super(
+            ClickHouseDDLCompiler, self
+        ).get_column_specification(column, **kw)
+
+        codec = column.dialect_options['clickhouse']['codec']
+        if codec:
+            if isinstance(codec, (list, tuple)):
+                codec = ', '.join(codec)
+            column_spec += " CODEC({0})".format(codec)
+
+        return column_spec
+
     def visit_create_column(self, create, **kw):
         column = create.element
         nullable = column.nullable
@@ -573,7 +588,10 @@ class ClickHouseDialect(default.DefaultDialect):
         (schema.Table, {
             'data': [],
             'cluster': None,
-        })
+        }),
+        (schema.Column, {
+            'codec': None,
+        }),
     ]
 
     def _execute(self, connection, sql):

--- a/clickhouse_sqlalchemy/drivers/base.py
+++ b/clickhouse_sqlalchemy/drivers/base.py
@@ -1,8 +1,6 @@
 import enum
 
-from sqlalchemy import (
-    schema, Column, types as sqltypes, exc, util as sa_util
-)
+from sqlalchemy import schema, types as sqltypes, exc, util as sa_util
 from sqlalchemy.engine import default, reflection
 from sqlalchemy.sql import (
     compiler, expression, type_api, literal_column, elements

--- a/tests/test_ddl.py
+++ b/tests/test_ddl.py
@@ -140,6 +140,34 @@ class DDLTestCase(BaseTestCase):
             'ENGINE = Memory'
         )
 
+    def test_create_table_with_codec(self):
+        table = Table(
+            't1', self.metadata(),
+            Column(
+                'list',
+                types.DateTime,
+                clickhouse_codec=['DoubleDelta', 'ZSTD'],
+            ),
+            Column(
+                'tuple',
+                types.UInt8,
+                clickhouse_codec=('T64', 'ZSTD(5)'),
+            ),
+            Column('explicit_none', types.UInt32, clickhouse_codec=None),
+            Column('str', types.Int8, clickhouse_codec='ZSTD'),
+            engines.Memory()
+        )
+
+        self.assertEqual(
+            self.compile(CreateTable(table)),
+            'CREATE TABLE t1 ('
+            'list DateTime CODEC(DoubleDelta, ZSTD), '
+            'tuple UInt8 CODEC(T64, ZSTD(5)), '
+            'explicit_none UInt32, '
+            'str Int8 CODEC(ZSTD)) '
+            'ENGINE = Memory'
+        )
+
     def test_table_create_on_cluster(self):
         create_sql = (
             'CREATE TABLE t1 ON CLUSTER test_cluster '


### PR DESCRIPTION
Continuing the discussion [from here](https://github.com/xzkostyan/clickhouse-sqlalchemy/issues/88#issuecomment-596418440), this implements the required changes to add support for the dialect-specific `CODEC(...)` column option. Thank you for the hints regarding the implementation, they proved helpful in getting this started! 

I got a little bit confused by your original message mentioning `visit_column` and realizing that this method only generates the column name, however looking around in the MSSQL implementation revealed that overriding `get_column_specification` appears the be the way to go. I never thought that MSSQL would prove to be helpful for anything in my life, but I stand corrected.

In the edited comment you changed it to `visit_create_column`, which I tested and can confirm that having the code in this method would also work. This PR currently implements the `get_column_specification` approach, but I could just as well move the code down a few lines if you'd prefer that -- just say the  word.

Also, would you want to advertise this feature in the README?

Fixes #88 