### PR TITLE
Improve IP types

### DIFF
--- a/clickhouse_sqlalchemy/types.py
+++ b/clickhouse_sqlalchemy/types.py
@@ -1,9 +1,10 @@
 from ipaddress import IPv4Network, IPv6Network
 
 from sqlalchemy.sql.type_api import to_instance, UserDefinedType
-from sqlalchemy import types, func, and_, or_
+from sqlalchemy import types, func
 from .ext.clauses import NestedColumn
 from .util.compat import text_type
+from clickhouse_sqlalchemy.util.comparators import BaseIPComparator
 
 
 class String(types.String):
@@ -178,24 +179,8 @@ class IPv4(types.UserDefinedType):
     def bind_expression(self, bindvalue):
         return func.toIPv4(bindvalue)
 
-    class comparator_factory(types.UserDefinedType.Comparator):
-        def in_(self, other):
-            if not isinstance(other, IPv4Network):
-                other = IPv4Network(other)
-
-            return and_(
-                self >= other[0],
-                self <= other[-1]
-            )
-
-        def notin_(self, other):
-            if not isinstance(other, IPv4Network):
-                other = IPv4Network(other)
-
-            return or_(
-                self < other[0],
-                self > other[-1]
-            )
+    class comparator_factory(BaseIPComparator):
+        network_class = IPv4Network
 
 
 class IPv6(types.UserDefinedType):
@@ -218,21 +203,5 @@ class IPv6(types.UserDefinedType):
     def bind_expression(self, bindvalue):
         return func.toIPv6(bindvalue)
 
-    class comparator_factory(types.UserDefinedType.Comparator):
-        def in_(self, other):
-            if not isinstance(other, IPv6Network):
-                other = IPv6Network(other)
-
-            return and_(
-                self >= other[0],
-                self <= other[-1]
-            )
-
-        def notin_(self, other):
-            if not isinstance(other, IPv6Network):
-                other = IPv6Network(other)
-
-            return or_(
-                self < other[0],
-                self > other[-1]
-            )
+    class comparator_factory(BaseIPComparator):
+        network_class = IPv6Network

--- a/clickhouse_sqlalchemy/types.py
+++ b/clickhouse_sqlalchemy/types.py
@@ -167,6 +167,14 @@ class IPv4(types.UserDefinedType):
 
         return process
 
+    def literal_processor(self, dialect):
+        bp = self.bind_processor(dialect)
+
+        def process(value):
+            return "'%s'" % bp(value)
+
+        return process
+
     def bind_expression(self, bindvalue):
         return func.toIPv4(bindvalue)
 
@@ -196,6 +204,14 @@ class IPv6(types.UserDefinedType):
     def bind_processor(self, dialect):
         def process(value):
             return text_type(value)
+
+        return process
+
+    def literal_processor(self, dialect):
+        bp = self.bind_processor(dialect)
+
+        def process(value):
+            return "'%s'" % bp(value)
 
         return process
 

--- a/clickhouse_sqlalchemy/util/comparators.py
+++ b/clickhouse_sqlalchemy/util/comparators.py
@@ -8,7 +8,8 @@ class BaseIPComparator(UserDefinedType.Comparator):
     def _split_other(self, other):
         """
         Split values between addresses and networks
-        This allows to generate complex filters with both addresses and networks in the same IN
+        This allows to generate complex filters with both addresses
+        and networks in the same IN
         ie in_('10.0.0.0/24', '192.168.0.1')
         """
         addresses = []

--- a/clickhouse_sqlalchemy/util/comparators.py
+++ b/clickhouse_sqlalchemy/util/comparators.py
@@ -26,7 +26,9 @@ class BaseIPComparator(UserDefinedType.Comparator):
     def in_(self, other):
         if isinstance(other, (list, tuple)):
             addresses, networks = self._split_other(other)
-            addresses_clause = super().in_(addresses) if addresses else None
+            addresses_clause = super(BaseIPComparator, self).in_(
+                addresses
+            ) if addresses else None
             networks_clause = or_(*[
                 and_(
                     self >= net[0],
@@ -55,7 +57,9 @@ class BaseIPComparator(UserDefinedType.Comparator):
     def notin_(self, other):
         if isinstance(other, (list, tuple)):
             addresses, networks = self._split_other(other)
-            addresses_clause = super().notin_(addresses) if addresses else None
+            addresses_clause = super(BaseIPComparator, self).notin_(
+                addresses
+            ) if addresses else None
             networks_clause = and_(*[
                 or_(
                     self < net[0],

--- a/clickhouse_sqlalchemy/util/comparators.py
+++ b/clickhouse_sqlalchemy/util/comparators.py
@@ -1,0 +1,81 @@
+from sqlalchemy import or_, and_
+from sqlalchemy.sql.type_api import UserDefinedType
+
+
+class BaseIPComparator(UserDefinedType.Comparator):
+    network_class = None
+
+    def _split_other(self, other):
+        """
+        Split values between addresses and networks
+        This allows to generate complex filters with both addresses and networks in the same IN
+        ie in_('10.0.0.0/24', '192.168.0.1')
+        """
+        addresses = []
+        networks = []
+        for sub in other:
+            sub = self.network_class(sub)
+            if sub.prefixlen == sub.max_prefixlen:
+                # this is an address
+                addresses.append(sub.network_address)
+            else:
+                networks.append(sub)
+        return addresses, networks
+
+    def in_(self, other):
+        if isinstance(other, (list, tuple)):
+            addresses, networks = self._split_other(other)
+            addresses_clause = super().in_(addresses) if addresses else None
+            networks_clause = or_(*[
+                and_(
+                    self >= net[0],
+                    self <= net[-1]
+                )
+                for net in networks
+            ]) if networks else None
+            if addresses_clause is not None and networks_clause is not None:
+                return or_(addresses_clause, networks_clause)
+            elif addresses_clause is not None and networks_clause is None:
+                return addresses_clause
+            elif networks_clause is not None and addresses_clause is None:
+                return networks_clause
+            else:
+                # other is an empty array
+                return super(BaseIPComparator, self).in_(other)
+
+        if not isinstance(other, self.network_class):
+            other = self.network_class(other)
+
+        return and_(
+            self >= other[0],
+            self <= other[-1]
+        )
+
+    def notin_(self, other):
+        if isinstance(other, (list, tuple)):
+            addresses, networks = self._split_other(other)
+            addresses_clause = super().notin_(addresses) if addresses else None
+            networks_clause = and_(*[
+                or_(
+                    self < net[0],
+                    self > net[-1]
+                )
+                for net in networks
+            ]) if networks else None
+            if addresses_clause is not None and networks_clause is not None:
+                return and_(addresses_clause, networks_clause)
+            elif addresses_clause is not None and networks_clause is None:
+                return addresses_clause
+            elif networks_clause is not None and addresses_clause is None:
+                return networks_clause
+            else:
+                # other is an empty array
+                return super(BaseIPComparator, self).notin_(other)
+
+        if not isinstance(other, self.network_class):
+            other = self.network_class(other)
+
+        return or_(
+            self < other[0],
+            self > other[-1]
+        )

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -174,6 +174,16 @@ class IPv4TestCase(TypesTestCase):
                      self.table.c.x < '10.0.0.2')).scalar(), a)
 
     @require_server_version(19, 3, 3)
+    def test_select_where_literal(self):
+        a = IPv4Address('10.0.0.1')
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(), [{'x': a}])
+            qs = self.session.query(self.table.c.x).filter(self.table.c.x == '10.0.0.1')
+            statement = self.compile(qs, literal_binds=True)
+            self.assertEqual(statement, """SELECT test.x AS test_x FROM test WHERE test.x = toIPv4('10.0.0.1')""")
+
+    @require_server_version(19, 3, 3)
     def test_select_in_network(self):
         ips = [
             IPv4Address('10.0.0.1'),
@@ -327,6 +337,16 @@ class IPv6TestCase(TypesTestCase):
             self.assertEqual(self.session.query(self.table.c.x).filter(
                 and_('42e::1' < self.table.c.x,
                      self.table.c.x < '42e::3')).scalar(), a)
+
+    @require_server_version(19, 3, 3)
+    def test_select_where_literal(self):
+        a = IPv6Address('42e::2')
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(), [{'x': a}])
+            qs = self.session.query(self.table.c.x).filter(self.table.c.x == '42e::2')
+            statement = self.compile(qs, literal_binds=True)
+            self.assertEqual(statement, """SELECT test.x AS test_x FROM test WHERE test.x = toIPv6('42e::2')""")
 
     @require_server_version(19, 3, 3)
     def test_select_in_network(self):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -205,6 +205,86 @@ class IPv4TestCase(TypesTestCase):
                 ])
 
     @require_server_version(19, 3, 3)
+    def test_select_in_list_address(self):
+        ips = [
+            IPv4Address('10.0.0.1'),
+            IPv4Address('10.0.0.2'),
+            IPv4Address('10.0.0.3'),
+            IPv4Address('192.168.0.1')
+        ]
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(),
+                                 [{'x': ip} for ip in ips])
+
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    self.table.c.x.in_([IPv4Address('10.0.0.1'), IPv4Address('10.0.0.2'), '10.0.0.3'])).all(), [
+                    (IPv4Address('10.0.0.1'),),
+                    (IPv4Address('10.0.0.2'),),
+                    (IPv4Address('10.0.0.3'),)
+                ])
+
+    @require_server_version(19, 3, 3)
+    def test_select_in_list_network(self):
+        ips = [
+            IPv4Address('10.0.0.1'),
+            IPv4Address('10.0.0.2'),
+            IPv4Address('10.1.0.3'),
+            IPv4Address('192.168.0.1')
+        ]
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(),
+                                 [{'x': ip} for ip in ips])
+
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    self.table.c.x.in_(['10.0.0.0/24', '10.1.0.0/24'])).all(), [
+                    (IPv4Address('10.0.0.1'),),
+                    (IPv4Address('10.0.0.2'),),
+                    (IPv4Address('10.1.0.3'),)
+                ])
+
+    @require_server_version(19, 3, 3)
+    def test_select_in_list_network_and_address(self):
+        ips = [
+            IPv4Address('10.0.0.1'),
+            IPv4Address('10.0.0.2'),
+            IPv4Address('10.1.0.3'),
+            IPv4Address('192.168.0.1')
+        ]
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(),
+                                 [{'x': ip} for ip in ips])
+
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    self.table.c.x.in_(['10.0.0.0/24', '10.1.0.3'])).all(), [
+                    (IPv4Address('10.0.0.1'),),
+                    (IPv4Address('10.0.0.2'),),
+                    (IPv4Address('10.1.0.3'),)
+                ])
+
+    @require_server_version(19, 3, 3)
+    def test_select_in_list_empty(self):
+        ips = [
+            IPv4Address('10.0.0.1'),
+            IPv4Address('10.0.0.2'),
+            IPv4Address('10.1.0.3'),
+            IPv4Address('192.168.0.1')
+        ]
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(),
+                                 [{'x': ip} for ip in ips])
+
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    self.table.c.x.in_([])).all(), [])
+
+    @require_server_version(19, 3, 3)
     def test_select_in_string(self):
         ips = [
             IPv4Address('10.0.0.1'),
@@ -273,6 +353,110 @@ class IPv4TestCase(TypesTestCase):
                     (IPv4Address('192.168.0.1'),)
                 ])
 
+    @require_server_version(19, 3, 3)
+    def test_select_not_in_list_address(self):
+        ips = [
+            IPv4Address('10.0.0.1'),
+            IPv4Address('10.0.0.2'),
+            IPv4Address('10.1.0.3'),
+            IPv4Address('192.168.0.1')
+        ]
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(),
+                                 [{'x': ip} for ip in ips])
+
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    self.table.c.x.notin_(['10.0.0.2', '10.1.0.3'])).all(), [
+                    (IPv4Address('10.0.0.1'),),
+                    (IPv4Address('192.168.0.1'),)
+                ])
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    ~self.table.c.x.in_(['10.0.0.2', '10.1.0.3'])).all(), [
+                    (IPv4Address('10.0.0.1'),),
+                    (IPv4Address('192.168.0.1'),)
+                ])
+
+    @require_server_version(19, 3, 3)
+    def test_select_not_in_list_network(self):
+        ips = [
+            IPv4Address('10.0.0.1'),
+            IPv4Address('10.0.0.2'),
+            IPv4Address('10.1.0.3'),
+            IPv4Address('192.168.0.1')
+        ]
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(),
+                                 [{'x': ip} for ip in ips])
+
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    self.table.c.x.notin_(['10.0.0.0/24', '10.1.0.0/24'])).all(), [
+                    (IPv4Address('192.168.0.1'),)
+                ])
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    ~self.table.c.x.in_(['10.0.0.0/24', '10.1.0.0/24'])).all(), [
+                    (IPv4Address('192.168.0.1'),)
+                ])
+
+    @require_server_version(19, 3, 3)
+    def test_select_not_in_list_network_address(self):
+        ips = [
+            IPv4Address('10.0.0.1'),
+            IPv4Address('10.0.0.2'),
+            IPv4Address('10.1.0.3'),
+            IPv4Address('192.168.0.1')
+        ]
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(),
+                                 [{'x': ip} for ip in ips])
+
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    self.table.c.x.notin_(['10.0.0.0/24', '10.1.0.3'])).all(), [
+                    (IPv4Address('192.168.0.1'),)
+                ])
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    ~self.table.c.x.in_(['10.0.0.0/24', '10.1.0.3'])).all(), [
+                    (IPv4Address('192.168.0.1'),)
+                ])
+
+    @require_server_version(19, 3, 3)
+    def test_select_not_in_list_empty(self):
+        ips = [
+            IPv4Address('10.0.0.1'),
+            IPv4Address('10.0.0.2'),
+            IPv4Address('10.1.0.3'),
+            IPv4Address('192.168.0.1')
+        ]
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(),
+                                 [{'x': ip} for ip in ips])
+
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    self.table.c.x.notin_([])).all(), [
+                    (IPv4Address('10.0.0.1'),),
+                    (IPv4Address('10.0.0.2'),),
+                    (IPv4Address('10.1.0.3'),),
+                    (IPv4Address('192.168.0.1'),)
+                ])
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    ~self.table.c.x.in_([])).all(), [
+                    (IPv4Address('10.0.0.1'),),
+                    (IPv4Address('10.0.0.2'),),
+                    (IPv4Address('10.1.0.3'),),
+                    (IPv4Address('192.168.0.1'),)
+                ])
+
 
 class IPv4HttpTestCase(IPv4TestCase, HttpSessionTestCase):
     """ IPv4 over a HTTP session """
@@ -335,6 +519,9 @@ class IPv6TestCase(TypesTestCase):
             self.session.execute(self.table.insert(), [{'x': a}])
 
             self.assertEqual(self.session.query(self.table.c.x).filter(
+                self.table.c.x == '42e::2').scalar(), a)
+
+            self.assertEqual(self.session.query(self.table.c.x).filter(
                 and_('42e::1' < self.table.c.x,
                      self.table.c.x < '42e::3')).scalar(), a)
 
@@ -368,6 +555,86 @@ class IPv6TestCase(TypesTestCase):
                     (IPv6Address('42e::2'),),
                     (IPv6Address('42e::3'),)
                 ])
+
+    @require_server_version(19, 3, 3)
+    def test_select_in_list_address(self):
+        ips = [
+            IPv6Address('42e::1'),
+            IPv6Address('42e::2'),
+            IPv6Address('7::3'),
+            IPv6Address('f42e::ffff')
+        ]
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(),
+                                 [{'x': ip} for ip in ips])
+
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    self.table.c.x.in_(['42e::1', '42e::2', 'f42e::ffff'])).all(), [
+                    (IPv6Address('42e::1'),),
+                    (IPv6Address('42e::2'),),
+                    (IPv6Address('f42e::ffff'),)
+                ])
+
+    @require_server_version(19, 3, 3)
+    def test_select_in_list_network(self):
+        ips = [
+            IPv6Address('42e::1'),
+            IPv6Address('42e::2'),
+            IPv6Address('a42e::3'),
+            IPv6Address('f42e::ffff')
+        ]
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(),
+                                 [{'x': ip} for ip in ips])
+
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    self.table.c.x.in_([IPv6Network('42e::/64'), IPv6Network('a42e::/48')])).all(), [
+                    (IPv6Address('42e::1'),),
+                    (IPv6Address('42e::2'),),
+                    (IPv6Address('a42e::3'),)
+                ])
+
+    @require_server_version(19, 3, 3)
+    def test_select_in_list_network_address(self):
+        ips = [
+            IPv6Address('42e::1'),
+            IPv6Address('42e::2'),
+            IPv6Address('a42e::3'),
+            IPv6Address('f42e::ffff')
+        ]
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(),
+                                 [{'x': ip} for ip in ips])
+
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    self.table.c.x.in_(['42e::/64', 'a42e::3'])).all(), [
+                    (IPv6Address('42e::1'),),
+                    (IPv6Address('42e::2'),),
+                    (IPv6Address('a42e::3'),)
+                ])
+
+    @require_server_version(19, 3, 3)
+    def test_select_in_list_empty(self):
+        ips = [
+            IPv6Address('42e::1'),
+            IPv6Address('42e::2'),
+            IPv6Address('a42e::3'),
+            IPv6Address('f42e::ffff')
+        ]
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(),
+                                 [{'x': ip} for ip in ips])
+
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    self.table.c.x.in_([])).all(), [])
 
     @require_server_version(19, 3, 3)
     def test_select_in_string(self):
@@ -435,6 +702,114 @@ class IPv6TestCase(TypesTestCase):
             self.assertEqual(
                 self.session.query(self.table.c.x).filter(
                     ~self.table.c.x.in_('42e::/64')).all(), [
+                    (IPv6Address('f42e::ffff'),)
+                ])
+
+    @require_server_version(19, 3, 3)
+    def test_select_not_in_list_address(self):
+        ips = [
+            IPv6Address('42e::1'),
+            IPv6Address('42e::2'),
+            IPv6Address('42e::3'),
+            IPv6Address('f42e::ffff')
+        ]
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(),
+                                 [{'x': ip} for ip in ips])
+
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    self.table.c.x.notin_(['42e::1', '42e::3'])).all(), [
+                    (IPv6Address('42e::2'),),
+                    (IPv6Address('f42e::ffff'),),
+                ])
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    ~self.table.c.x.in_(['42e::1', '42e::3'])).all(), [
+                    (IPv6Address('42e::2'),),
+                    (IPv6Address('f42e::ffff'),),
+                ])
+
+    @require_server_version(19, 3, 3)
+    def test_select_not_in_list_network(self):
+        ips = [
+            IPv6Address('1234::1'),
+            IPv6Address('42e::2'),
+            IPv6Address('beef::3'),
+            IPv6Address('f42e::ffff')
+        ]
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(),
+                                 [{'x': ip} for ip in ips])
+
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    self.table.c.x.notin_(['42e::/64', 'beef::/64'])).all(), [
+                    (IPv6Address('1234::1'),),
+                    (IPv6Address('f42e::ffff'),)
+                ])
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    ~self.table.c.x.in_(['42e::/64', 'beef::/64'])).all(), [
+                    (IPv6Address('1234::1'),),
+                    (IPv6Address('f42e::ffff'),)
+                ])
+
+    @require_server_version(19, 3, 3)
+    def test_select_not_in_list_network_address(self):
+        ips = [
+            IPv6Address('1234::1'),
+            IPv6Address('42e::2'),
+            IPv6Address('beef::3'),
+            IPv6Address('f42e::ffff')
+        ]
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(),
+                                 [{'x': ip} for ip in ips])
+
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    self.table.c.x.notin_(['42e::/64', 'beef::3'])).all(), [
+                    (IPv6Address('1234::1'),),
+                    (IPv6Address('f42e::ffff'),)
+                ])
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    ~self.table.c.x.in_(['42e::/64', 'beef::3'])).all(), [
+                    (IPv6Address('1234::1'),),
+                    (IPv6Address('f42e::ffff'),)
+                ])
+
+    @require_server_version(19, 3, 3)
+    def test_select_not_in_list_empty(self):
+        ips = [
+            IPv6Address('1234::1'),
+            IPv6Address('42e::2'),
+            IPv6Address('beef::3'),
+            IPv6Address('f42e::ffff')
+        ]
+
+        with self.create_table(self.table):
+            self.session.execute(self.table.insert(),
+                                 [{'x': ip} for ip in ips])
+
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    self.table.c.x.notin_([])).all(), [
+                    (IPv6Address('1234::1'),),
+                    (IPv6Address('42e::2'),),
+                    (IPv6Address('beef::3'),),
+                    (IPv6Address('f42e::ffff'),)
+                ])
+            self.assertEqual(
+                self.session.query(self.table.c.x).filter(
+                    ~self.table.c.x.in_([])).all(), [
+                    (IPv6Address('1234::1'),),
+                    (IPv6Address('42e::2'),),
+                    (IPv6Address('beef::3'),),
                     (IPv6Address('f42e::ffff'),)
                 ])
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -179,9 +179,13 @@ class IPv4TestCase(TypesTestCase):
 
         with self.create_table(self.table):
             self.session.execute(self.table.insert(), [{'x': a}])
-            qs = self.session.query(self.table.c.x).filter(self.table.c.x == '10.0.0.1')
+            qs = self.session.query(self.table.c.x).filter(
+                self.table.c.x == '10.0.0.1'
+            )
             statement = self.compile(qs, literal_binds=True)
-            self.assertEqual(statement, """SELECT test.x AS test_x FROM test WHERE test.x = toIPv4('10.0.0.1')""")
+            self.assertEqual(statement,
+                             "SELECT test.x AS test_x FROM test "
+                             "WHERE test.x = toIPv4('10.0.0.1')")
 
     @require_server_version(19, 3, 3)
     def test_select_in_network(self):
@@ -219,7 +223,11 @@ class IPv4TestCase(TypesTestCase):
 
             self.assertEqual(
                 self.session.query(self.table.c.x).filter(
-                    self.table.c.x.in_([IPv4Address('10.0.0.1'), IPv4Address('10.0.0.2'), '10.0.0.3'])).all(), [
+                    self.table.c.x.in_([
+                        IPv4Address('10.0.0.1'),
+                        IPv4Address('10.0.0.2'),
+                        '10.0.0.3'
+                    ])).all(), [
                     (IPv4Address('10.0.0.1'),),
                     (IPv4Address('10.0.0.2'),),
                     (IPv4Address('10.0.0.3'),)
@@ -240,7 +248,8 @@ class IPv4TestCase(TypesTestCase):
 
             self.assertEqual(
                 self.session.query(self.table.c.x).filter(
-                    self.table.c.x.in_(['10.0.0.0/24', '10.1.0.0/24'])).all(), [
+                    self.table.c.x.in_(['10.0.0.0/24',
+                                        '10.1.0.0/24'])).all(), [
                     (IPv4Address('10.0.0.1'),),
                     (IPv4Address('10.0.0.2'),),
                     (IPv4Address('10.1.0.3'),)
@@ -394,12 +403,14 @@ class IPv4TestCase(TypesTestCase):
 
             self.assertEqual(
                 self.session.query(self.table.c.x).filter(
-                    self.table.c.x.notin_(['10.0.0.0/24', '10.1.0.0/24'])).all(), [
+                    self.table.c.x.notin_(['10.0.0.0/24',
+                                           '10.1.0.0/24'])).all(), [
                     (IPv4Address('192.168.0.1'),)
                 ])
             self.assertEqual(
                 self.session.query(self.table.c.x).filter(
-                    ~self.table.c.x.in_(['10.0.0.0/24', '10.1.0.0/24'])).all(), [
+                    ~self.table.c.x.in_(['10.0.0.0/24',
+                                         '10.1.0.0/24'])).all(), [
                     (IPv4Address('192.168.0.1'),)
                 ])
 
@@ -418,12 +429,14 @@ class IPv4TestCase(TypesTestCase):
 
             self.assertEqual(
                 self.session.query(self.table.c.x).filter(
-                    self.table.c.x.notin_(['10.0.0.0/24', '10.1.0.3'])).all(), [
+                    self.table.c.x.notin_(['10.0.0.0/24', '10.1.0.3'])).all(),
+                [
                     (IPv4Address('192.168.0.1'),)
                 ])
             self.assertEqual(
                 self.session.query(self.table.c.x).filter(
-                    ~self.table.c.x.in_(['10.0.0.0/24', '10.1.0.3'])).all(), [
+                    ~self.table.c.x.in_(['10.0.0.0/24', '10.1.0.3'])).all(),
+                [
                     (IPv4Address('192.168.0.1'),)
                 ])
 
@@ -531,9 +544,12 @@ class IPv6TestCase(TypesTestCase):
 
         with self.create_table(self.table):
             self.session.execute(self.table.insert(), [{'x': a}])
-            qs = self.session.query(self.table.c.x).filter(self.table.c.x == '42e::2')
+            qs = self.session.query(self.table.c.x).filter(
+                self.table.c.x == '42e::2')
             statement = self.compile(qs, literal_binds=True)
-            self.assertEqual(statement, """SELECT test.x AS test_x FROM test WHERE test.x = toIPv6('42e::2')""")
+            self.assertEqual(statement,
+                             "SELECT test.x AS test_x FROM test "
+                             "WHERE test.x = toIPv6('42e::2')")
 
     @require_server_version(19, 3, 3)
     def test_select_in_network(self):
@@ -571,7 +587,8 @@ class IPv6TestCase(TypesTestCase):
 
             self.assertEqual(
                 self.session.query(self.table.c.x).filter(
-                    self.table.c.x.in_(['42e::1', '42e::2', 'f42e::ffff'])).all(), [
+                    self.table.c.x.in_(['42e::1', '42e::2',
+                                        'f42e::ffff'])).all(), [
                     (IPv6Address('42e::1'),),
                     (IPv6Address('42e::2'),),
                     (IPv6Address('f42e::ffff'),)
@@ -592,7 +609,8 @@ class IPv6TestCase(TypesTestCase):
 
             self.assertEqual(
                 self.session.query(self.table.c.x).filter(
-                    self.table.c.x.in_([IPv6Network('42e::/64'), IPv6Network('a42e::/48')])).all(), [
+                    self.table.c.x.in_([IPv6Network('42e::/64'),
+                                        IPv6Network('a42e::/48')])).all(), [
                     (IPv6Address('42e::1'),),
                     (IPv6Address('42e::2'),),
                     (IPv6Address('a42e::3'),)


### PR DESCRIPTION
This improves the IP types support in 2 aspects:
- add support for literal binds (was missing)
- extensive implementation of IN and NOT IN comparators (compared to the primitive one currently in place)

The Comparator implementation is here to overcome the basic Clickhouse implementation for IP types by generating complex AND & OR combinations, but this has the advantage of covering a lot - if not all - cases (see tests).

As the IPv4 and IPv6 comparators have exactly the same behavior, I've extracted a common base implementation to keep it clean.

All the required tests are added.
