### PR TITLE
Fix if_exists and on_cluster AttributeError-s

### DIFF
--- a/clickhouse_sqlalchemy/drivers/base.py
+++ b/clickhouse_sqlalchemy/drivers/base.py
@@ -526,12 +526,12 @@ class ClickHouseDDLCompiler(compiler.DDLCompiler):
     def visit_drop_table(self, drop):
         text = '\nDROP TABLE '
 
-        if drop.if_exists:
+        if getattr(drop, "if_exists", False):
             text += 'IF EXISTS '
 
         rv = text + self.preparer.format_table(drop.element)
 
-        if drop.on_cluster:
+        if getattr(drop, "on_cluster", False):
             rv += (
                 ' ON CLUSTER ' +
                 self.preparer.quote(drop.on_cluster)


### PR DESCRIPTION
This PR makes the following code execute without errors:
```python
import sqlalchemy
import clickhouse_sqlalchemy.engines

metadata = sqlalchemy.MetaData()

notes = sqlalchemy.Table(
    "notes",
    metadata,
    sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
    sqlalchemy.Column("text", sqlalchemy.String(length=100)),
    clickhouse_sqlalchemy.engines.Memory(),
)

engine = sqlalchemy.create_engine("clickhouse://default:@0.0.0.0:8123")
metadata.create_all(engine)
metadata.drop_all(engine)
```

Related to #22

**Can you please make a new PyPI release after merging this.**