### PR TITLE
TTL param for engine

### DIFF
--- a/clickhouse_sqlalchemy/drivers/base.py
+++ b/clickhouse_sqlalchemy/drivers/base.py
@@ -541,6 +541,14 @@ class ClickHouseDDLCompiler(compiler.DDLCompiler):
                     engine.sample_by.get_expressions_or_columns()[0]
                 )
             )
+        if engine.ttl:
+            compile = self.sql_compiler.process
+            text += ' TTL {0}\n'.format(
+                ', \n     '.join(
+                    compile(i, include_table=False, literal_binds=True)
+                    for i in engine.ttl.get_expressions_or_columns(),
+                )
+            )
         if engine.settings:
             text += ' SETTINGS ' + ', '.join(
                 '{key}={value}'.format(

--- a/clickhouse_sqlalchemy/drivers/base.py
+++ b/clickhouse_sqlalchemy/drivers/base.py
@@ -544,7 +544,7 @@ class ClickHouseDDLCompiler(compiler.DDLCompiler):
         if engine.ttl:
             compile = self.sql_compiler.process
             text += ' TTL {0}\n'.format(
-                ', \n     '.join(
+                ',\n     '.join(
                     compile(i, include_table=False, literal_binds=True)
                     for i in engine.ttl.get_expressions_or_columns(),
                 )

--- a/clickhouse_sqlalchemy/engines/mergetree.py
+++ b/clickhouse_sqlalchemy/engines/mergetree.py
@@ -14,6 +14,7 @@ class MergeTree(Engine):
             order_by=None,
             primary_key=None,
             sample_by=None,
+            ttl=None,
             **settings
     ):
         self.partition_by = None
@@ -31,6 +32,11 @@ class MergeTree(Engine):
         self.sample_by = None
         if sample_by is not None:
             self.sample_by = KeysExpressionOrColumn(sample_by)
+
+        self.ttl = None
+        if ttl is not None:
+            self.ttl = KeysExpressionOrColumn(*to_list(ttl))
+
         self.settings = settings
         super(MergeTree, self).__init__()
 

--- a/clickhouse_sqlalchemy/engines/mergetree.py
+++ b/clickhouse_sqlalchemy/engines/mergetree.py
@@ -50,11 +50,13 @@ class MergeTree(Engine):
             self.primary_key._set_parent(table)
         if self.sample_by is not None:
             self.sample_by._set_parent(table)
+        if self.ttl is not None:
+            self.ttl._set_parent(table)
 
     @classmethod
     def _reflect_merge_tree(
             self, partition_key=None, sorting_key=None, primary_key=None,
-            sampling_key=None, **kwargs):
+            sampling_key=None, ttl=None, **kwargs):
 
         # TODO: reflect settings
         rv = {}
@@ -66,6 +68,8 @@ class MergeTree(Engine):
             rv['primary_key'] = parse_columns(primary_key)
         if sampling_key:
             rv['sample_by'] = parse_columns(sampling_key)
+        if ttl:
+            rv['ttl'] = parse_columns(ttl)
 
         return rv
 

--- a/clickhouse_sqlalchemy/sql/ddl.py
+++ b/clickhouse_sqlalchemy/sql/ddl.py
@@ -1,6 +1,8 @@
 from sqlalchemy.sql.ddl import (
     SchemaDropper as SchemaDropperBase, DropTable as DropTableBase
 )
+from sqlalchemy.sql.expression import UnaryExpression
+from sqlalchemy.sql.operators import custom_op
 
 
 class DropTable(DropTableBase):
@@ -17,3 +19,17 @@ class SchemaDropper(SchemaDropperBase):
 
     def visit_table(self, table, drop_ok=False, _is_metadata_operation=False):
         self.connection.execute(DropTable(table, if_exists=self.if_exists))
+
+
+def ttl_delete(expr):
+    return UnaryExpression(expr, modifier=custom_op('DELETE'))
+
+
+def ttl_to_disk(expr, disk):
+    assert isinstance(disk, str), 'Disk must be str'
+    return expr.op('TO DISK')(disk)
+
+
+def ttl_to_volume(expr, volume):
+    assert isinstance(volume, str), 'Volume must be str'
+    return expr.op('TO VOLUME')(volume)

--- a/tests/engines/test_compilation.py
+++ b/tests/engines/test_compilation.py
@@ -2,6 +2,7 @@ from sqlalchemy import Column, func, exc
 from sqlalchemy.sql.ddl import CreateTable
 
 from clickhouse_sqlalchemy import types, engines, get_declarative_base, Table
+from clickhouse_sqlalchemy.sql.ddl import ttl_delete, ttl_to_disk, ttl_to_volume
 from tests.testcase import CompilationTestCase
 
 
@@ -592,4 +593,66 @@ class MiscEnginesTestCase(EngineTestCaseBase):
             self.compile(CreateTable(TestTable.__table__)),
             'CREATE TABLE test_table (date Date, x Int32) '
             'ENGINE = Memory'
+        )
+
+
+class TTLTestCase(EngineTestCaseBase):
+    def test_ttl_expr(self):
+        class TestTable(self.base):
+            date = Column(types.Date, primary_key=True)
+            x = Column(types.Int32)
+
+            __table_args__ = (
+                engines.MergeTree(
+                    ttl=date + func.toIntervalDay(1),
+                ),
+            )
+
+        self.assertEqual(
+            self.compile(CreateTable(TestTable.__table__)),
+            'CREATE TABLE test_table (date Date, x Int32) '
+            'ENGINE = MergeTree()'
+            ' TTL date + toIntervalDay(1)'
+        )
+
+    def test_ttl_delete(self):
+        class TestTable(self.base):
+            date = Column(types.Date, primary_key=True)
+            x = Column(types.Int32)
+
+            __table_args__ = (
+                engines.MergeTree(
+                    ttl=ttl_delete(date + func.toIntervalDay(1)),
+                ),
+            )
+
+        self.assertEqual(
+            self.compile(CreateTable(TestTable.__table__)),
+            'CREATE TABLE test_table (date Date, x Int32) '
+            'ENGINE = MergeTree()'
+            ' TTL date + toIntervalDay(1) DELETE'
+        )
+
+    def test_ttl_list(self):
+        class TestTable(self.base):
+            date = Column(types.Date, primary_key=True)
+            x = Column(types.Int32)
+
+            __table_args__ = (
+                engines.MergeTree(
+                    ttl=[
+                        ttl_delete(date + func.toIntervalDay(1)),
+                        ttl_to_disk(date + func.toIntervalDay(1), 'hdd'),
+                        ttl_to_volume(date + func.toIntervalDay(1), 'slow'),
+                    ],
+                ),
+            )
+
+        self.assertEqual(
+            self.compile(CreateTable(TestTable.__table__)),
+            'CREATE TABLE test_table (date Date, x Int32) '
+            'ENGINE = MergeTree()'
+            ' TTL date + toIntervalDay(1) DELETE,'
+            '      date + toIntervalDay(1) TO DISK \'hdd\','
+            '      date + toIntervalDay(1) TO VOLUME \'slow\''
         )

--- a/tests/engines/test_compilation.py
+++ b/tests/engines/test_compilation.py
@@ -653,6 +653,6 @@ class TTLTestCase(EngineTestCaseBase):
             'CREATE TABLE test_table (date Date, x Int32) '
             'ENGINE = MergeTree()'
             ' TTL date + toIntervalDay(1) DELETE,'
-            '      date + toIntervalDay(1) TO DISK \'hdd\','
-            '      date + toIntervalDay(1) TO VOLUME \'slow\''
+            '     date + toIntervalDay(1) TO DISK \'hdd\','
+            '     date + toIntervalDay(1) TO VOLUME \'slow\''
         )

--- a/tests/engines/test_compilation.py
+++ b/tests/engines/test_compilation.py
@@ -615,8 +615,8 @@ class TTLTestCase(EngineTestCaseBase):
         self.assertEqual(
             self.compile(CreateTable(TestTable.__table__)),
             'CREATE TABLE test_table (date Date, x Int32) '
-            'ENGINE = MergeTree()'
-            ' TTL date + toIntervalDay(1)'
+            'ENGINE = MergeTree() '
+            'TTL date + toIntervalDay(1)'
         )
 
     def test_ttl_delete(self):
@@ -633,8 +633,8 @@ class TTLTestCase(EngineTestCaseBase):
         self.assertEqual(
             self.compile(CreateTable(TestTable.__table__)),
             'CREATE TABLE test_table (date Date, x Int32) '
-            'ENGINE = MergeTree()'
-            ' TTL date + toIntervalDay(1) DELETE'
+            'ENGINE = MergeTree() '
+            'TTL date + toIntervalDay(1) DELETE'
         )
 
     def test_ttl_list(self):
@@ -655,8 +655,8 @@ class TTLTestCase(EngineTestCaseBase):
         self.assertEqual(
             self.compile(CreateTable(TestTable.__table__)),
             'CREATE TABLE test_table (date Date, x Int32) '
-            'ENGINE = MergeTree()'
-            ' TTL date + toIntervalDay(1) DELETE,'
-            '     date + toIntervalDay(1) TO DISK \'hdd\','
-            '     date + toIntervalDay(1) TO VOLUME \'slow\''
+            'ENGINE = MergeTree() '
+            'TTL date + toIntervalDay(1) DELETE, '
+            '    date + toIntervalDay(1) TO DISK \'hdd\', '
+            '    date + toIntervalDay(1) TO VOLUME \'slow\''
         )

--- a/tests/engines/test_compilation.py
+++ b/tests/engines/test_compilation.py
@@ -2,7 +2,11 @@ from sqlalchemy import Column, func, exc
 from sqlalchemy.sql.ddl import CreateTable
 
 from clickhouse_sqlalchemy import types, engines, get_declarative_base, Table
-from clickhouse_sqlalchemy.sql.ddl import ttl_delete, ttl_to_disk, ttl_to_volume
+from clickhouse_sqlalchemy.sql.ddl import (
+    ttl_delete,
+    ttl_to_disk,
+    ttl_to_volume,
+)
 from tests.testcase import CompilationTestCase
 
 

--- a/tests/engines/test_reflection.py
+++ b/tests/engines/test_reflection.py
@@ -369,3 +369,27 @@ class EngineClassReflectionTestCase(BaseTestCase):
         engine.__init__.assert_called_with(
             'default', 'test', 16, 10, 100, 10000, 1000000, 10000000, 100000000
         )
+
+    def test_ttl_replicated_merge_tree(self):
+        engine = engines.ReplicatedMergeTree
+        engine_full = (
+            "ReplicatedMergeTree('/table/path', 'name') "
+            "PARTITION BY x ORDER BY x PRIMARY KEY x TTL x"
+        )
+
+        engine.__init__ = Mock(return_value=None)
+        engine.reflect(
+            engine_full,
+            partition_key='x',
+            sorting_key='x',
+            primary_key='x',
+            ttl='x',
+        )
+
+        engine.__init__.assert_called_with(
+            '/table/path', 'name',
+            partition_by=['x'],
+            order_by=['x'],
+            primary_key=['x'],
+            ttl=['x'],
+        )


### PR DESCRIPTION
Implementation for TTL

```
CREATE TABLE example_table
(
    d DateTime,
    a Int
)
ENGINE = MergeTree
PARTITION BY toYYYYMM(d)
ORDER BY d
TTL d + INTERVAL 1 MONTH [DELETE],
    d + INTERVAL 1 WEEK TO VOLUME 'aaa',
    d + INTERVAL 2 WEEK TO DISK 'bbb';
```

Usage

        from clickhouse_sqlalchemy.sql.ddl import ttl_delete, ttl_to_disk, ttl_to_volume

        class TestTable(self.base):
            date = Column(types.Date, primary_key=True)
            x = Column(types.Int32)

            __table_args__ = (
                engines.MergeTree(
                    ttl=[
                        ttl_delete(date + func.toIntervalDay(1)),
                        ttl_to_disk(date + func.toIntervalDay(1), 'hdd'),
                        ttl_to_volume(date + func.toIntervalDay(1), 'slow'),
                    ],
                ),
            )
