### PR TITLE
Fix server version parsing (non-numeric build)

### DIFF
--- a/clickhouse_sqlalchemy/drivers/base.py
+++ b/clickhouse_sqlalchemy/drivers/base.py
@@ -1018,7 +1018,8 @@ class ClickHouseDialect(default.DefaultDialect):
             version = self._query_server_version_string(connection)
             assert version
 
-        return tuple(int(part) for part in version.split('.'))
+        # The first three are numeric, but the last is an alphanumeric build.
+        return tuple(int(p) if p.isdigit() else p for p in version.split('.'))
 
     def _query_server_version_string(self, connection):
         raise NotImplementedError


### PR DESCRIPTION
The server version handling code is assuming all version components are numeric, which isn't the case when the fourth component is a build tag (such as `12-stable-98abc83`). This causes an exception when connecting to servers.

This PR keeps version components as a string when they can't be parsed as an integer (although I feel the proper course of action here would be returning the unparsed version in the tuple, and then use `distutils.version.LooseVersion` for comparisons in `ClickHouseDialect.initialize()`.