### PR TITLE
Allow custom requests.Session for HTTP

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,19 @@ When you are using `nginx` as proxy server for ClickHouse server connection stri
 
 Where ``8124`` is proxy port.
 
+If you need control over the underlying HTTP connection, pass a `requests.Session
+<https://requests.readthedocs.io/en/master/user/advanced/#session-objects>`_ instance
+to ``create_engine()``, like so:
+
+    .. code-block:: python
+
+        from sqlalchemy import create_engine
+        from requests import Session
+
+        uri = 'clickhouse://default:@localhost/test'
+
+        engine = create_engine(uri, connect_args={'http_session': Session()})
+
 
 Native
 ------

--- a/clickhouse_sqlalchemy/__init__.py
+++ b/clickhouse_sqlalchemy/__init__.py
@@ -4,7 +4,7 @@ from .orm.session import make_session
 from .sql import Table, select
 
 
-VERSION = (0, 1, 5)
+VERSION = (0, 1, 6)
 __version__ = '.'.join(str(x) for x in VERSION)
 
 

--- a/clickhouse_sqlalchemy/drivers/http/transport.py
+++ b/clickhouse_sqlalchemy/drivers/http/transport.py
@@ -85,8 +85,8 @@ class RequestsTransport(object):
         if ddl_timeout is not None:
             self.ch_settings['distributed_ddl_task_timeout'] = int(ddl_timeout)
 
-        # Keep connection open between queries.
-        self.http = requests.Session()
+        # By default, keep connection open between queries.
+        self.http = kwargs.pop('http_session', requests.Session())
 
         super(RequestsTransport, self).__init__()
 


### PR DESCRIPTION
By allowing the user to pass a `requests.Session` object (or subclass instance), it becomes possible to manipulate the underlying HTTP connection in custom ways without modifying the driver.

Example use cases:

* Complex mocking of database responses for testing;
* Transparently cache (some) responses;
* Perform complex authentication;
* ...

The version is bumped to 0.1.6 because this introduces a change in the API and allows users to specify `>=0.1.6` in their requirements files.