### PR TITLE
Don't lose information on unicode conversion

### DIFF
--- a/clickhouse_sqlalchemy/__init__.py
+++ b/clickhouse_sqlalchemy/__init__.py
@@ -4,7 +4,7 @@ from .orm.session import make_session
 from .sql import Table, select
 
 
-VERSION = (0, 1, 5)
+VERSION = (0, 1, 6)
 __version__ = '.'.join(str(x) for x in VERSION)
 
 

--- a/clickhouse_sqlalchemy/drivers/http/transport.py
+++ b/clickhouse_sqlalchemy/drivers/http/transport.py
@@ -78,7 +78,8 @@ class RequestsTransport(object):
             if key.startswith('header__')
         }
 
-        self.use_surrogates = kwargs.pop('surrogate_encoding', False)
+        se_option = kwargs.pop('surrogate_encoding', '').lower() == 'true'
+        self.use_surrogates = se_option
 
         ch_settings = dict(ch_settings or {})
         self.ch_settings = ch_settings

--- a/clickhouse_sqlalchemy/drivers/http/transport.py
+++ b/clickhouse_sqlalchemy/drivers/http/transport.py
@@ -78,8 +78,7 @@ class RequestsTransport(object):
             if key.startswith('header__')
         }
 
-        se_option = kwargs.pop('surrogate_encoding', '').lower() == 'true'
-        self.use_surrogates = se_option
+        self.unicode_errors = kwargs.pop('unicode_errors', 'escape')
 
         ch_settings = dict(ch_settings or {})
         self.ch_settings = ch_settings
@@ -101,8 +100,8 @@ class RequestsTransport(object):
         r = self._send(query, params=params, stream=True)
         lines = r.iter_lines()
         try:
-            names = parse_tsv(next(lines), self.use_surrogates)
-            types = parse_tsv(next(lines), self.use_surrogates)
+            names = parse_tsv(next(lines), self.unicode_errors)
+            types = parse_tsv(next(lines), self.unicode_errors)
         except StopIteration:
             # Empty result; e.g. a DDL request.
             return
@@ -115,7 +114,7 @@ class RequestsTransport(object):
         for line in lines:
             yield [
                 (conv(x) if conv else x)
-                for x, conv in zip(parse_tsv(line, self.use_surrogates), convs)
+                for x, conv in zip(parse_tsv(line, self.unicode_errors), convs)
             ]
 
     def raw(self, query, params=None, stream=False):

--- a/clickhouse_sqlalchemy/drivers/http/utils.py
+++ b/clickhouse_sqlalchemy/drivers/http/utils.py
@@ -10,8 +10,6 @@ def unescape(value, use_surrogates=False):
 
 
 def parse_tsv(line, use_surrogates=False):
-    if line and line[-1] == b'\n':
-        line = line[:-1]
     return [
         (unescape(x, use_surrogates) if x != b'\\N' else None)
         for x in line.split(b'\t')

--- a/clickhouse_sqlalchemy/drivers/http/utils.py
+++ b/clickhouse_sqlalchemy/drivers/http/utils.py
@@ -1,16 +1,14 @@
 import codecs
 
 
-def unescape(value, use_surrogates=False):
-    # Surrogates keep strings reversible to what's really in the database.
-    errors = 'surrogateescape' if use_surrogates else 'replace'
-
-    # Things like '\0' arrive as '\\0' and must be escaped explicitly.
+def unescape(value, errors=None):
+    if errors is None:
+        errors = 'replace'
     return codecs.escape_decode(value)[0].decode('utf-8', errors=errors)
 
 
-def parse_tsv(line, use_surrogates=False):
+def parse_tsv(line, errors=None):
     return [
-        (unescape(x, use_surrogates) if x != b'\\N' else None)
+        (unescape(x, errors) if x != b'\\N' else None)
         for x in line.split(b'\t')
     ]

--- a/clickhouse_sqlalchemy/drivers/http/utils.py
+++ b/clickhouse_sqlalchemy/drivers/http/utils.py
@@ -1,11 +1,18 @@
 import codecs
 
 
-def unescape(value):
-    return codecs.escape_decode(value)[0].decode('utf-8', errors='replace')
+def unescape(value, use_surrogates=False):
+    # Surrogates keep strings reversible to what's really in the database.
+    errors = 'surrogateescape' if use_surrogates else 'replace'
+
+    # Things like '\0' arrive as '\\0' and must be escaped explicitly.
+    return codecs.escape_decode(value)[0].decode('utf-8', errors=errors)
 
 
-def parse_tsv(line):
+def parse_tsv(line, use_surrogates=False):
     if line and line[-1] == b'\n':
         line = line[:-1]
-    return [unescape(x) if x != b'\\N' else None for x in line.split(b'\t')]
+    return [
+        (unescape(x, use_surrogates) if x != b'\\N' else None)
+        for x in line.split(b'\t')
+    ]

--- a/tests/drivers/http/test_utils.py
+++ b/tests/drivers/http/test_utils.py
@@ -10,7 +10,7 @@ class HttpUtilsTestCase(BaseTestCase):
 
     def test_unescape_surrogates(self):
         test_values = [b'', b'a', b'\xc3\xa3\xff\xf6\0\x00\n', b'a\n\\0']
-        actual = [unescape(t, use_surrogates=True) for t in test_values]
+        actual = [unescape(t, errors='surrogateescape') for t in test_values]
         expected = [u'', u'a', u'ã\udcff\udcf6\x00\x00\n', u'a\n\x00']
         self.assertListEqual(actual, expected)
 
@@ -21,7 +21,7 @@ class HttpUtilsTestCase(BaseTestCase):
         # What comes over the wire:
         test_values = [b'', b'a', b'\xc3\xa3\xff\x55\xf6\0\x00\x45\\0\n']
 
-        escaped = [unescape(t, use_surrogates=True) for t in test_values]
+        escaped = [unescape(t, errors='surrogateescape') for t in test_values]
         actual = [t.encode('utf-8', errors='surrogateescape') for t in escaped]
         self.assertListEqual(actual, expected)
 

--- a/tests/drivers/http/test_utils.py
+++ b/tests/drivers/http/test_utils.py
@@ -8,6 +8,23 @@ class HttpUtilsTestCase(BaseTestCase):
         actual = [unescape(t) for t in test_values]
         self.assertListEqual(actual, [u'', u'a', u'\ufffd'])
 
+    def test_unescape_surrogates(self):
+        test_values = [b'', b'a', b'\xc3\xa3\xff\xf6\0\x00\n', b'a\n\\0']
+        actual = [unescape(t, use_surrogates=True) for t in test_values]
+        expected = [u'', u'a', u'ã\udcff\udcf6\x00\x00\n', u'a\n\x00']
+        self.assertListEqual(actual, expected)
+
+    def test_reverse_surrogates(self):
+        # What's stored in the database:
+        expected = [b'', b'a', b'\xc3\xa3\xff\x55\xf6\0\x00\x45\0\n']
+
+        # What comes over the wire:
+        test_values = [b'', b'a', b'\xc3\xa3\xff\x55\xf6\0\x00\x45\\0\n']
+
+        escaped = [unescape(t, use_surrogates=True) for t in test_values]
+        actual = [t.encode('utf-8', errors='surrogateescape') for t in escaped]
+        self.assertListEqual(actual, expected)
+
     def test_parse_tsv(self):
         test_values = [b'', b'a\tb\tc', b'a\tb\t\xff']
         try:

--- a/tests/drivers/http/test_utils.py
+++ b/tests/drivers/http/test_utils.py
@@ -26,11 +26,13 @@ class HttpUtilsTestCase(BaseTestCase):
         self.assertListEqual(actual, expected)
 
     def test_parse_tsv(self):
-        test_values = [b'', b'a\tb\tc', b'a\tb\t\xff']
+        test_values = [b'', b'a\tb\tc\n', b'a\tb\t\xff']
+        expected = [[u''], [u'a', u'b', u'c\n'], [u'a', u'b', u'\ufffd']]
         try:
-            for value in test_values:
-                parse_tsv(value)
+            actual = [parse_tsv(value) for value in test_values]
         except IndexError:
             self.fail('"parse_tsv" raised IndexError exception!')
         except TypeError:
             self.fail('"parse_tsv" raised TypeError exception!')
+
+        self.assertListEqual(actual, expected)


### PR DESCRIPTION
By default strings are being decoded into unicode in a way that makes it impossible to encode them back into what's actually in the database (`errors='replace'`). This causes "data loss" when tables have columns that are supposed to store raw bytes.

An option `unicode_errors` is added that allows changing this behavior (e.g. by passing `unicode_errors=surrogateescape`). The default behavior is kept unchanged for compatibility and the driver minor version is bumped.