### PR TITLE
Fixed reflection functions to handle schema and views

### DIFF
--- a/clickhouse_sqlalchemy/engines/__init__.py
+++ b/clickhouse_sqlalchemy/engines/__init__.py
@@ -3,7 +3,10 @@ from .mergetree import (
     MergeTree, AggregatingMergeTree, GraphiteMergeTree, CollapsingMergeTree,
     VersionedCollapsingMergeTree, ReplacingMergeTree, SummingMergeTree
 )
-from .misc import Distributed, Buffer, TinyLog, Log, Memory, Null, File
+from .misc import (
+    Distributed, View, MaterializedView,
+    Buffer, TinyLog, Log, Memory, Null, File
+)
 from .replicated import (
     ReplicatedMergeTree, ReplicatedAggregatingMergeTree,
     ReplicatedCollapsingMergeTree, ReplicatedVersionedCollapsingMergeTree,
@@ -26,6 +29,8 @@ __all__ = (
     ReplicatedVersionedCollapsingMergeTree,
     ReplicatedReplacingMergeTree,
     ReplicatedSummingMergeTree,
+    View,
+    MaterializedView,
     Buffer,
     TinyLog,
     Log,

--- a/clickhouse_sqlalchemy/engines/misc.py
+++ b/clickhouse_sqlalchemy/engines/misc.py
@@ -87,6 +87,14 @@ class _NoParamsEngine(Engine):
         return cls()
 
 
+class View(_NoParamsEngine):
+    pass
+
+
+class MaterializedView(_NoParamsEngine):
+    pass
+
+
 class TinyLog(_NoParamsEngine):
     pass
 

--- a/tests/drivers/test_clickhouse_dialect.py
+++ b/tests/drivers/test_clickhouse_dialect.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, create_engine
+from sqlalchemy import Column, create_engine, inspect
 
 from clickhouse_sqlalchemy import make_session, engines, types, Table
 from tests.testcase import BaseTestCase
@@ -42,10 +42,53 @@ class ClickHouseDialectTestCase(BaseTestCase):
                                    self.table.name)
         )
 
+    def test_has_table_with_schema(self):
+        self.assertFalse(
+            self.dialect.has_table(self.session, 'bad', schema='system')
+        )
+        self.assertTrue(
+            self.dialect.has_table(self.session, 'columns', schema='system')
+        )
+
     def test_get_table_names(self):
         self.table.create(self.session.bind)
         db_tables = self.dialect.get_table_names(self.session)
         self.assertIn(self.table.name, db_tables)
+
+    def test_get_table_names_with_schema(self):
+        self.table.create(self.session.bind)
+        db_tables = self.dialect.get_table_names(self.session, 'system')
+        self.assertIn('columns', db_tables)
+
+    def test_get_view_names(self):
+        self.table.create(self.session.bind)
+        db_views = self.dialect.get_view_names(self.session)
+        self.assertNotIn(self.table.name, db_views)
+
+    def test_get_view_names_with_schema(self):
+        self.table.create(self.session.bind)
+        db_views = self.dialect.get_view_names(self.session, test_database)
+        self.assertNotIn(self.table.name, db_views)
+
+    def test_reflecttable(self):
+        self.table.create(self.session.bind)
+        meta = self.metadata()
+        insp = inspect(self.session.bind)
+        reflected_table = Table(self.table.name, meta)
+        insp.reflecttable(reflected_table, None)
+
+        self.assertEqual(self.table.name, reflected_table.name)
+
+    def test_reflecttable_with_schema(self):
+        # Imitates calling sequence for clients like Superset that look
+        # across schemas.
+        meta = self.metadata()
+        insp = inspect(self.session.bind)
+        reflected_table = Table('columns', meta, schema='system')
+        insp.reflecttable(reflected_table, None)
+
+        self.assertEqual(reflected_table.name, 'columns')
+        self.assertEqual(reflected_table.schema, 'system')
 
     def test_get_schema_names(self):
         schemas = self.dialect.get_schema_names(self.session)


### PR DESCRIPTION
This PR fixes three things that came up in testing against Superset. With 
these changes it is possible in Superset to create datasets on views 
as well as on tables in schemas other than the default schema.  
Listings of tables and views no longer overlap. 

1.) Enable reflection functions like get_table_names() to work across
    schemas. Previously the schema argument was ignored.
2.) Correctly distinguish between views and tables in get_table_names()
    and get_view_names().
3.) Support table reflection for View and MaterializedView engines.

Unit tests are updated to show correct behavior.  There is one failing test 
that seems to be unrelated to this PR. (test_insert_truncate)