### PR TITLE
Support for session factories

### DIFF
--- a/clickhouse_sqlalchemy/drivers/http/transport.py
+++ b/clickhouse_sqlalchemy/drivers/http/transport.py
@@ -115,7 +115,8 @@ class RequestsTransport(object):
             self.ch_settings['distributed_ddl_task_timeout'] = int(ddl_timeout)
 
         # By default, keep connection open between queries.
-        self.http = kwargs.pop('http_session', requests.Session())
+        http = kwargs.pop('http_session', requests.Session)
+        self.http = http() if callable(http) else http
 
         super(RequestsTransport, self).__init__()
 


### PR DESCRIPTION
Currently, passing a custom `requests.Session` combined with connection pooling makes all connections share the same custom instance, which allows for more control but may be unexpected.

The change in this PR allows either passing a `requests.Session` instance as until now, or a callable (function, method, class) so that each connection transparently initializes its own separate instance.