### PR TITLE
Fix default Unicode error handler

### DIFF
--- a/clickhouse_sqlalchemy/drivers/http/transport.py
+++ b/clickhouse_sqlalchemy/drivers/http/transport.py
@@ -108,7 +108,7 @@ class RequestsTransport(object):
             if key.startswith('header__')
         }
 
-        self.unicode_errors = kwargs.pop('unicode_errors', 'escape')
+        self.unicode_errors = kwargs.pop('unicode_errors', 'replace')
 
         ch_settings = dict(ch_settings or {})
         self.ch_settings = ch_settings


### PR DESCRIPTION
The current default Unicode error handler `escape` does not exist and will cause an error when triggered (`unknown error handler name 'escape'`). This changes it back to `replace` which is what it was before https://github.com/xzkostyan/clickhouse-sqlalchemy/pull/120.