### PR TITLE
use http params to specify clickhouse data format

### DIFF
--- a/clickhouse_sqlalchemy/drivers/http/base.py
+++ b/clickhouse_sqlalchemy/drivers/http/base.py
@@ -1,4 +1,3 @@
-
 import sqlalchemy as sa
 from sqlalchemy.util import asbool
 
@@ -8,6 +7,7 @@ from . import connector
 
 # Export connector version
 VERSION = (0, 0, 2, None)
+
 
 class ClickHouseExecutionContext(ClickHouseExecutionContextBase):
     def pre_exec(self):

--- a/clickhouse_sqlalchemy/drivers/http/base.py
+++ b/clickhouse_sqlalchemy/drivers/http/base.py
@@ -9,6 +9,10 @@ from . import connector
 # Export connector version
 VERSION = (0, 0, 2, None)
 
+class ClickHouseExecutionContext(ClickHouseExecutionContextBase):
+    def pre_exec(self):
+        pass
+
 
 class ClickHouseDialect_http(ClickHouseDialect):
     driver = 'http'

--- a/clickhouse_sqlalchemy/drivers/http/base.py
+++ b/clickhouse_sqlalchemy/drivers/http/base.py
@@ -2,20 +2,12 @@
 import sqlalchemy as sa
 from sqlalchemy.util import asbool
 
-from .utils import FORMAT_SUFFIX
 from ..base import ClickHouseDialect, ClickHouseExecutionContextBase
 from . import connector
 
 
 # Export connector version
 VERSION = (0, 0, 2, None)
-
-
-class ClickHouseExecutionContext(ClickHouseExecutionContextBase):
-    def pre_exec(self):
-        # TODO: refactor
-        if not self.isinsert and not self.isddl:
-            self.statement += ' ' + FORMAT_SUFFIX
 
 
 class ClickHouseDialect_http(ClickHouseDialect):

--- a/clickhouse_sqlalchemy/drivers/http/connector.py
+++ b/clickhouse_sqlalchemy/drivers/http/connector.py
@@ -2,7 +2,6 @@ from uuid import uuid4
 
 from .escaper import Escaper
 from .transport import RequestsTransport
-from .utils import FORMAT_SUFFIX
 
 # PEP 249 module globals
 apilevel = '2.0'
@@ -107,10 +106,6 @@ class Cursor(object):
 
         if parameters is not None:
             raw_sql = raw_sql % self._params_escaper.escape(parameters)
-
-        raw_sql_big = raw_sql.upper()
-        if 'FORMAT' not in raw_sql_big and 'INSERT' not in raw_sql_big:
-            raw_sql += ' ' + FORMAT_SUFFIX
 
         self._reset_state()
         self._begin_query()

--- a/clickhouse_sqlalchemy/drivers/http/transport.py
+++ b/clickhouse_sqlalchemy/drivers/http/transport.py
@@ -113,7 +113,7 @@ class RequestsTransport(object):
         ch_settings = dict(ch_settings or {})
         self.ch_settings = ch_settings
 
-        self.ch_settings['default_format'] = 'TabSeparatedWithNamesAndTypes' 
+        self.ch_settings['default_format'] = 'TabSeparatedWithNamesAndTypes'
 
         ddl_timeout = kwargs.pop('ddl_timeout', DEFAULT_DDL_TIMEOUT)
         if ddl_timeout is not None:

--- a/clickhouse_sqlalchemy/drivers/http/transport.py
+++ b/clickhouse_sqlalchemy/drivers/http/transport.py
@@ -113,6 +113,8 @@ class RequestsTransport(object):
         ch_settings = dict(ch_settings or {})
         self.ch_settings = ch_settings
 
+        self.ch_settings['default_format'] = 'TabSeparatedWithNamesAndTypes' 
+
         ddl_timeout = kwargs.pop('ddl_timeout', DEFAULT_DDL_TIMEOUT)
         if ddl_timeout is not None:
             self.ch_settings['distributed_ddl_task_timeout'] = int(ddl_timeout)

--- a/clickhouse_sqlalchemy/drivers/http/utils.py
+++ b/clickhouse_sqlalchemy/drivers/http/utils.py
@@ -1,9 +1,6 @@
 import codecs
 
 
-FORMAT_SUFFIX = 'FORMAT TabSeparatedWithNamesAndTypes'
-
-
 def unescape(value, errors=None):
     if errors is None:
         errors = 'replace'

--- a/tests/drivers/http/test_select.py
+++ b/tests/drivers/http/test_select.py
@@ -38,7 +38,7 @@ class FormatSectionTestCase(HttpSessionTestCase):
         statement = self.compile(self.session.query(table.c.x), bind=bind)
         self.assertEqual(
             statement,
-            'SELECT t1.x AS t1_x FROM t1 FORMAT TabSeparatedWithNamesAndTypes'
+            'SELECT t1.x AS t1_x FROM t1'
         )
 
     def test_insert_from_select_no_format_clause(self):

--- a/tests/util.py
+++ b/tests/util.py
@@ -28,7 +28,7 @@ def require_server_version(*version_required):
             else:
                 cursor = conn.cursor()
                 cursor.execute(
-                    'SELECT version() FORMAT TabSeparatedWithNamesAndTypes'
+                    'SELECT version()'
                 )
                 version = cursor.fetchall()[0][0].split('.')
                 current = tuple(int(x) for x in version[:3])


### PR DESCRIPTION
- fixes #168 

It is very disgusting to rewrite sql with 'FORMAT TabSeparatedWithNamesAndTypes' and it may cause some other problems.
Instead, we can add a http params to solve it easily.
see: https://github.com/ClickHouse/ClickHouse/blob/ab9fc572d536ec9b3b7b2ac8628a3824bdeeda4c/src/Server/HTTPHandler.cpp#L734
