### PR TITLE
Add native Boolean type (Bool)

### DIFF
--- a/clickhouse_sqlalchemy/drivers/base.py
+++ b/clickhouse_sqlalchemy/drivers/base.py
@@ -41,6 +41,8 @@ ischema_names = {
     'Float32': FLOAT,
     'Decimal': types.Decimal,
     'String': types.String,
+    'Bool': types.Boolean,
+    'Boolean': types.Boolean,
     'UUID': types.UUID,
     'IPv4': types.IPv4,
     'IPv6': types.IPv6,

--- a/clickhouse_sqlalchemy/drivers/base.py
+++ b/clickhouse_sqlalchemy/drivers/base.py
@@ -83,7 +83,7 @@ class ClickHouseDialect(default.DefaultDialect):
     supports_sane_rowcount = False
     supports_sane_multi_rowcount = False
     supports_native_decimal = True
-    supports_native_boolean = False
+    supports_native_boolean = True
     non_native_boolean_check_constraint = False
     supports_alter = True
     supports_sequences = False

--- a/clickhouse_sqlalchemy/drivers/compilers/typecompiler.py
+++ b/clickhouse_sqlalchemy/drivers/compilers/typecompiler.py
@@ -79,7 +79,7 @@ class ClickHouseTypeCompiler(compiler.GenericTypeCompiler):
         return 'Decimal(%s, %s)' % (type_.precision, type_.scale)
 
     def visit_boolean(self, type_, **kw):
-        return 'UInt8'
+        return 'Bool'
 
     def visit_nested(self, nested, **kwargs):
         ddl_compiler = self.dialect.ddl_compiler(self.dialect, None)

--- a/clickhouse_sqlalchemy/types/__init__.py
+++ b/clickhouse_sqlalchemy/types/__init__.py
@@ -2,6 +2,7 @@ __all__ = [
     'String',
     'Int',
     'Float',
+    'Boolean',
     'Array',
     'Nullable',
     'UUID',
@@ -37,6 +38,7 @@ __all__ = [
 from .common import String
 from .common import Int
 from .common import Float
+from .common import Boolean
 from .common import Array
 from .common import Nullable
 from .common import UUID

--- a/clickhouse_sqlalchemy/types/common.py
+++ b/clickhouse_sqlalchemy/types/common.py
@@ -23,6 +23,10 @@ class Float(types.Float, ClickHouseTypeEngine):
     pass
 
 
+class Boolean(types.Boolean, ClickHouseTypeEngine):
+    pass
+
+
 class Array(ClickHouseTypeEngine):
     __visit_name__ = 'array'
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -7,8 +7,8 @@ from tests.testcase import CompilationTestCase, NativeSessionTestCase
 
 class VisitTestCase(CompilationTestCase):
     def test_true_false(self):
-        self.assertEqual(self.compile(sql.false()), '0')
-        self.assertEqual(self.compile(sql.true()), '1')
+        self.assertEqual(self.compile(sql.false()), 'false')
+        self.assertEqual(self.compile(sql.true()), 'true')
 
     def test_array(self):
         self.assertEqual(

--- a/tests/types/test_boolean.py
+++ b/tests/types/test_boolean.py
@@ -15,12 +15,12 @@ class BooleanCompilationTestCase(CompilationTestCase):
     def test_create_table(self):
         self.assertEqual(
             self.compile(CreateTable(self.table)),
-            'CREATE TABLE test (x UInt8) ENGINE = Memory'
+            'CREATE TABLE test (x Bool) ENGINE = Memory'
         )
 
     def test_literals(self):
         query = self.session.query(self.table.c.x).filter(self.table.c.x)
         self.assertEqual(
             self.compile(query),
-            'SELECT test.x AS test_x FROM test WHERE test.x = 1'
+            'SELECT test.x AS test_x FROM test WHERE test.x'
         )


### PR DESCRIPTION
<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #212

Could not find any relevant doc entries to update.

Note, I changed the ClickHouseDialect configuration `supports_native_boolean` to `True`. This seemed like a reasonable thing to do but I am not sure exactly how that effects things? Similarly, `non_native_boolean_check_constraint` is kept as is but I do not know what this does either.

With these changes I got it to work as I would like and it allows Alembic migrations for tables with Boolean columns.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [x] Run `flake8` and fix issues.
- [x] Run `pytest` no tests failed. See https://clickhouse-driver.readthedocs.io/en/latest/development.html.
