### PR TITLE
Fix inconsistency in isshema_names type converters

### DIFF
--- a/clickhouse_sqlalchemy/drivers/base.py
+++ b/clickhouse_sqlalchemy/drivers/base.py
@@ -5,7 +5,6 @@ from sqlalchemy.engine import default, reflection
 from sqlalchemy.sql import (
     compiler, elements
 )
-from sqlalchemy.types import DATE, DATETIME, FLOAT
 from sqlalchemy.util import (
     warn,
 )
@@ -34,11 +33,11 @@ ischema_names = {
     'UInt32': types.UInt32,
     'UInt16': types.UInt16,
     'UInt8': types.UInt8,
-    'Date': DATE,
-    'DateTime': DATETIME,
-    'DateTime64': DATETIME,
-    'Float64': FLOAT,
-    'Float32': FLOAT,
+    'Date': types.Date,
+    'DateTime': types.DateTime,
+    'DateTime64': types.DateTime64,
+    'Float64': types.Float64,
+    'Float32': types.Float32,
     'Decimal': types.Decimal,
     'String': types.String,
     'Bool': types.Boolean,


### PR DESCRIPTION
The type converters dictionary had inconsistencies in how types were mapped between each other. One of these meant that the automatic migration of type changes in a column would fail. This fix resolved the issue.

- fixes #215

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [x] Run `flake8` and fix issues.
- [x] Run `pytest` no tests failed. See https://clickhouse-driver.readthedocs.io/en/latest/development.html.
