### PR TITLE
Do not add `AFTER <column>` on column in `CREATE TABLE` statements

### DIFF
--- a/clickhouse_sqlalchemy/drivers/compilers/ddlcompiler.py
+++ b/clickhouse_sqlalchemy/drivers/compilers/ddlcompiler.py
@@ -70,6 +70,9 @@ class ClickHouseDDLCompiler(compiler.DDLCompiler):
         # All columns including synthetic PKs must be 'nullable'
         column.nullable = True
 
+        # Remove invalid column options for create table statements
+        column.dialect_options['clickhouse']["after"] = None
+
         rv = super(ClickHouseDDLCompiler, self).visit_create_column(
             create, **kw
         )

--- a/tests/test_ddl.py
+++ b/tests/test_ddl.py
@@ -279,7 +279,7 @@ class DDLTestCase(BaseTestCase):
 
         self.assertEqual(
             self.compile(CreateColumn(col)),
-            'x2 Int8 AFTER x1'
+            'x2 Int8'
         )
 
     def test_create_table_tuple(self):


### PR DESCRIPTION
<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #219

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [x] Run `flake8` and fix issues.
- [x] Run `pytest` no tests failed. See https://clickhouse-driver.readthedocs.io/en/latest/development.html.
