### PR TITLE
feat: Added support for regexp_match

### DIFF
--- a/clickhouse_sqlalchemy/drivers/compilers/sqlcompiler.py
+++ b/clickhouse_sqlalchemy/drivers/compilers/sqlcompiler.py
@@ -466,3 +466,15 @@ class ClickHouseSQLCompiler(compiler.SQLCompiler):
             return super(ClickHouseSQLCompiler, self).render_literal_value(
                 value, type_
             )
+
+    def _get_regexp_args(self, binary, kw):
+        string = self.process(binary.left, **kw)
+        pattern = self.process(binary.right, **kw)
+        return string, pattern
+
+    def visit_regexp_match_op_binary(self, binary, operator, **kw):
+        string, pattern = self._get_regexp_args(binary, kw)
+        return "MATCH(%s, %s)" % (string, pattern)
+
+    def visit_not_regexp_match_op_binary(self, binary, operator, **kw):
+        return "NOT %s" % self.visit_regexp_match_op_binary(binary, operator, **kw)

--- a/clickhouse_sqlalchemy/drivers/compilers/sqlcompiler.py
+++ b/clickhouse_sqlalchemy/drivers/compilers/sqlcompiler.py
@@ -477,4 +477,8 @@ class ClickHouseSQLCompiler(compiler.SQLCompiler):
         return "MATCH(%s, %s)" % (string, pattern)
 
     def visit_not_regexp_match_op_binary(self, binary, operator, **kw):
-        return "NOT %s" % self.visit_regexp_match_op_binary(binary, operator, **kw)
+        return "NOT %s" % self.visit_regexp_match_op_binary(
+            binary,
+            operator,
+            **kw
+        )

--- a/tests/sql/test_regexp_match.py
+++ b/tests/sql/test_regexp_match.py
@@ -1,12 +1,12 @@
 from sqlalchemy import Column, not_
 from clickhouse_sqlalchemy import types, Table
 
-
 from tests.testcase import BaseTestCase
+
 
 class RegexpMatch(BaseTestCase):
     table = Table(
-        't1', 
+        't1',
         BaseTestCase.metadata(),
         Column('x', types.Int32, primary_key=True),
         Column('y', types.String)

--- a/tests/sql/test_regexp_match.py
+++ b/tests/sql/test_regexp_match.py
@@ -1,0 +1,35 @@
+from sqlalchemy import Column, not_
+from clickhouse_sqlalchemy import types, Table
+
+
+from tests.testcase import BaseTestCase
+
+class RegexpMatch(BaseTestCase):
+    table = Table(
+        't1', 
+        BaseTestCase.metadata(),
+        Column('x', types.Int32, primary_key=True),
+        Column('y', types.String)
+    )
+
+    def test_regex_match(self):
+        query = (
+            self.session.query(self.table.c.x)
+            .where(self.table.c.y.regexp_match('^s.*'))
+        )
+
+        self.assertEqual(
+            self.compile(query, literal_binds=True),
+            "SELECT t1.x AS t1_x FROM t1 WHERE MATCH(t1.y, '^s.*')"
+        )
+
+    def test_not_regex_match(self):
+        query = (
+            self.session.query(self.table.c.x)
+            .where(not_(self.table.c.y.regexp_match('^s.*')))
+        )
+
+        self.assertEqual(
+            self.compile(query, literal_binds=True),
+            "SELECT t1.x AS t1_x FROM t1 WHERE NOT MATCH(t1.y, '^s.*')"
+        )


### PR DESCRIPTION
Implements Clickhouse `regexp_match` https://docs.sqlalchemy.org/en/14/core/sqlelement.html#sqlalchemy.sql.expression.ColumnElement.regexp_match


Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [x] Run `flake8` and fix issues.
- [x] Run `pytest` no tests failed. See https://clickhouse-driver.readthedocs.io/en/latest/development.html.
