### PR TITLE
added ilike clause compilation

### DIFF
--- a/clickhouse_sqlalchemy/drivers/compilers/sqlcompiler.py
+++ b/clickhouse_sqlalchemy/drivers/compilers/sqlcompiler.py
@@ -482,3 +482,18 @@ class ClickHouseSQLCompiler(compiler.SQLCompiler):
             operator,
             **kw
         )
+
+    def visit_ilike_case_insensitive_operand(self, element, **kw):
+        return element.element._compiler_dispatch(self, **kw)
+
+    def visit_ilike_op_binary(self, binary, operator, **kw):
+        return "%s ILIKE %s" % (
+            self.process(binary.left, **kw),
+            self.process(binary.right, **kw)
+        )
+
+    def visit_not_ilike_op_binary(self, binary, operator, **kw):
+        return "%s NOT ILIKE %s" % (
+            self.process(binary.left, **kw),
+            self.process(binary.right, **kw)
+        )

--- a/tests/sql/test_ilike.py
+++ b/tests/sql/test_ilike.py
@@ -1,0 +1,35 @@
+from sqlalchemy import Column
+from clickhouse_sqlalchemy import types, Table
+
+from tests.testcase import BaseTestCase
+
+
+class ILike(BaseTestCase):
+    table = Table(
+        't1',
+        BaseTestCase.metadata(),
+        Column('x', types.Int32, primary_key=True),
+        Column('y', types.String)
+    )
+
+    def test_ilike(self):
+        query = (
+            self.session.query(self.table.c.x)
+            .where(self.table.c.y.ilike('y'))
+        )
+
+        self.assertEqual(
+            self.compile(query, literal_binds=True),
+            "SELECT t1.x AS t1_x FROM t1 WHERE t1.y ILIKE 'y'"
+        )
+
+    def test_not_ilike(self):
+        query = (
+            self.session.query(self.table.c.x)
+            .where(self.table.c.y.not_ilike('y'))
+        )
+
+        self.assertEqual(
+            self.compile(query, literal_binds=True),
+            "SELECT t1.x AS t1_x FROM t1 WHERE t1.y NOT ILIKE 'y'"
+        )


### PR DESCRIPTION
- fixes #228

`column.ilike("text")` was compiled like `lower(column) LIKE lower(text)` request instead of `column ILIKE 'text'`. lower() function in Clickhouse works only with ASCII symbols. So, if column and text contained non-ASCII symbols, ilike operation worked not as expected. In this fix compilation of `ilike()` and 'not_ilike()' methods like `column ILIKE 'text'` and `column NOT ILIKE 'text'` is implemented.

Checklist:

- [ x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ x] Add or update relevant docs, in the docs folder and in code.
- [ x] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [ x] Run `flake8` and fix issues.
- [ x] Run `pytest` no tests failed. See https://clickhouse-driver.readthedocs.io/en/latest/development.html.
