### PR TITLE
Make Alembic comparators respect non-clickhouse engines for multi-db …

### DIFF
--- a/clickhouse_sqlalchemy/alembic/comparators.py
+++ b/clickhouse_sqlalchemy/alembic/comparators.py
@@ -21,7 +21,7 @@ def _extract_to_table_name(create_table_query):
     return inner_name.split('.')[1] if '.' in inner_name else inner_name
 
 
-@comparators.dispatch_for('schema')
+@comparators.dispatch_for('schema', 'clickhouse')
 def compare_mat_view(autogen_context, upgrade_ops, schemas):
     connection = autogen_context.connection
     dialect = autogen_context.dialect


### PR DESCRIPTION
Small tweak that make custom ClickHouse Alembic comparator respect non-clickhouse engines in multi-db configurations.

Without tweak autogeneration producing exceptions like:

```shell
/venv/lib/python3.9/site-packages/clickhouse_sqlalchemy/alembic/comparators.py", line 31, in compare_mat_view
   database_engine = dialect._execute(
AttributeError: 'PGDialect_psycopg2' object has no attribute '_execute'
```

Looks like tests passed and adoption doesn't broke clickhouse integration. 