### PR TITLE
Make respect non clickhouse engines

### DIFF
--- a/clickhouse_sqlalchemy/alembic/comparators.py
+++ b/clickhouse_sqlalchemy/alembic/comparators.py
@@ -21,6 +21,14 @@ def _extract_to_table_name(create_table_query):
     return inner_name.split('.')[1] if '.' in inner_name else inner_name
 
 
+# Direct call .dispatch_for('schema', 'clickhouse') override an Alembic
+# default ('schema', 'default') comparator. To avoid it (as we have own
+# implementation only for a materialized views ) register default "schema"
+# comparators as "clickhouse" comparators too.
+for default_comparator in comparators._registry[('schema', 'default')]:
+    comparators.dispatch_for('schema', 'clickhouse')(default_comparator)
+
+
 @comparators.dispatch_for('schema', 'clickhouse')
 def compare_mat_view(autogen_context, upgrade_ops, schemas):
     connection = autogen_context.connection

--- a/tests/alembic/test_default_schema_comparators.py
+++ b/tests/alembic/test_default_schema_comparators.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+
 from clickhouse_sqlalchemy.alembic.comparators import comparators, compare_mat_view
 
 

--- a/tests/alembic/test_default_schema_comparators.py
+++ b/tests/alembic/test_default_schema_comparators.py
@@ -1,0 +1,13 @@
+from unittest import TestCase
+from clickhouse_sqlalchemy.alembic.comparators import comparators, compare_mat_view
+
+
+class AlembicComparatorsTestCase(TestCase):
+    def test_default_schema_comparators(self):
+        default_schema_comparators = comparators._registry[('schema', 'default')]
+        clickhouse_schema_comparators = comparators._registry[('schema', 'clickhouse')]
+
+        for comparator in default_schema_comparators:
+            self.assertIn(comparator, clickhouse_schema_comparators)
+
+        self.assertNotIn(compare_mat_view, default_schema_comparators)

--- a/tests/alembic/test_default_schema_comparators.py
+++ b/tests/alembic/test_default_schema_comparators.py
@@ -1,14 +1,16 @@
 from unittest import TestCase
 
-from clickhouse_sqlalchemy.alembic.comparators import comparators, compare_mat_view
+from clickhouse_sqlalchemy.alembic.comparators import (
+    comparators, compare_mat_view
+)
 
 
 class AlembicComparatorsTestCase(TestCase):
     def test_default_schema_comparators(self):
-        default_schema_comparators = comparators._registry[('schema', 'default')]
-        clickhouse_schema_comparators = comparators._registry[('schema', 'clickhouse')]
+        default_schema = comparators._registry[('schema', 'default')]
+        clickhouse_schema = comparators._registry[('schema', 'clickhouse')]
 
-        for comparator in default_schema_comparators:
-            self.assertIn(comparator, clickhouse_schema_comparators)
+        for comparator in default_schema:
+            self.assertIn(comparator, clickhouse_schema)
 
-        self.assertNotIn(compare_mat_view, default_schema_comparators)
+        self.assertNotIn(compare_mat_view, default_schema)

--- a/testsrequire.py
+++ b/testsrequire.py
@@ -3,6 +3,7 @@ tests_require = [
     'pytest',
     'sqlalchemy>=1.4.24,<1.5',
     'greenlet>=2.0.1',
+    'alembic',
     'requests',
     'responses',
     'parameterized'


### PR DESCRIPTION
I'm really sorry ˙◠˙ for my previous PR, but it broke default Alembic schema comparators for ClickHouse.

I did fix, that register default `('schema', 'default')` comparators for `('schema', 'clickhouse')` _registry branch and added small test case that check it.

Checklist:
- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Run `pytest` no tests failed. See https://clickhouse-driver.readthedocs.io/en/latest/development.html.
