### PR TITLE
Trigger events before and after drop table

### DIFF
--- a/clickhouse_sqlalchemy/alembic/dialect.py
+++ b/clickhouse_sqlalchemy/alembic/dialect.py
@@ -25,7 +25,15 @@ class ClickHouseDialectImpl(impl.DefaultImpl):
     transactional_ddl = False
 
     def drop_table(self, table):
+        table.dispatch.before_drop(
+            table, self.connection, checkfirst=False, _ddl_runner=self
+        )
+
         self._exec(DropTable(table))
+
+        table.dispatch.after_drop(
+            table, self.connection, checkfirst=False, _ddl_runner=self
+        )
 
 
 def patch_alembic_version(context, **kwargs):

--- a/clickhouse_sqlalchemy/sql/ddl.py
+++ b/clickhouse_sqlalchemy/sql/ddl.py
@@ -25,7 +25,21 @@ class SchemaDropper(SchemaDropperBase):
         super(SchemaDropper, self).__init__(dialect, connection, **kwargs)
 
     def visit_table(self, table, **kwargs):
+        table.dispatch.before_drop(
+            table,
+            self.connection,
+            checkfirst=self.checkfirst,
+            _ddl_runner=self,
+        )
+
         self.connection.execute(DropTable(table, if_exists=self.if_exists))
+
+        table.dispatch.after_drop(
+            table,
+            self.connection,
+            checkfirst=self.checkfirst,
+            _ddl_runner=self,
+        )
 
     def visit_materialized_view(self, table, **kwargs):
         self.connection.execute(DropView(table, if_exists=self.if_exists))


### PR DESCRIPTION
- fixes #245

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [x] Run `flake8` and fix issues.
- [x] Run `pytest` no tests failed. See https://clickhouse-driver.readthedocs.io/en/latest/development.html.
