### PR TITLE
Remove greenlet dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,6 @@ setup(
     python_requires='>=3.7, <4',
     install_requires=[
         'sqlalchemy>=1.4.24,<1.5',
-        'greenlet>=2.0.1',
         'requests',
         'clickhouse-driver>=0.1.2',
         'asynch>=0.2.2',


### PR DESCRIPTION
The `greenlet>=2.0.1` requirement is forced on all projects importing this package, but it's actually not imported (except from tests for which it already is listed in `testsrequire.py`).

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [x] Run `flake8` and fix issues.
- [x] Run `pytest` no tests failed. See https://clickhouse-sqlalchemy.readthedocs.io/en/latest/development.html.
