### PR TITLE
refactor: run pyupgrade with --py37-plus option

### DIFF
--- a/clickhouse_sqlalchemy/__init__.py
+++ b/clickhouse_sqlalchemy/__init__.py
@@ -1,4 +1,3 @@
-
 from .ext.declarative import get_declarative_base
 from .orm.session import make_session
 from .sql import Table, MaterializedView, select

--- a/clickhouse_sqlalchemy/drivers/base.py
+++ b/clickhouse_sqlalchemy/drivers/base.py
@@ -59,9 +59,9 @@ ischema_names = {
 
 class ClickHouseIdentifierPreparer(compiler.IdentifierPreparer):
 
-    reserved_words = compiler.IdentifierPreparer.reserved_words | set((
+    reserved_words = compiler.IdentifierPreparer.reserved_words | {
         'index',  # reserved in the 'create table' syntax, at least.
-    ))
+    }
     # Alternatively, use `_requires_quotes = lambda self, value: True`
 
     def _escape_identifier(self, value):
@@ -133,7 +133,7 @@ class ClickHouseDialect(default.DefaultDialect):
     inspector = ClickHouseInspector
 
     def initialize(self, connection):
-        super(ClickHouseDialect, self).initialize(connection)
+        super().initialize(connection)
 
         version = self.server_version_info
 
@@ -162,7 +162,7 @@ class ClickHouseDialect(default.DefaultDialect):
             qualified_name = quote(schema) + '.' + quote(table_name)
         else:
             qualified_name = quote(table_name)
-        query = text('EXISTS TABLE {}'.format(qualified_name))
+        query = text(f'EXISTS TABLE {qualified_name}')
         for r in self._execute(connection, query):
             if r.result == 1:
                 return True
@@ -181,7 +181,7 @@ class ClickHouseDialect(default.DefaultDialect):
             qualified_name = quote(schema) + '.' + quote(table_name)
         else:
             qualified_name = quote(table_name)
-        query = 'DESCRIBE TABLE {}'.format(qualified_name)
+        query = f'DESCRIBE TABLE {qualified_name}'
         rows = self._execute(connection, query)
 
         return [
@@ -483,7 +483,7 @@ class ClickHouseDialect(default.DefaultDialect):
     def connect(self, *cargs, **cparams):
         self.forced_server_version_string = cparams.pop(
             'server_version', self.forced_server_version_string)
-        return super(ClickHouseDialect, self).connect(*cargs, **cparams)
+        return super().connect(*cargs, **cparams)
 
 
 clickhouse_dialect = ClickHouseDialect()

--- a/clickhouse_sqlalchemy/drivers/compilers/ddlcompiler.py
+++ b/clickhouse_sqlalchemy/drivers/compilers/ddlcompiler.py
@@ -57,7 +57,7 @@ class ClickHouseDDLCompiler(compiler.DDLCompiler):
         if codec is not None:
             if isinstance(codec, (list, tuple)):
                 codec = ', '.join(codec)
-            colspec += " CODEC({0})".format(codec)
+            colspec += f" CODEC({codec})"
 
         if opts['after'] is not None:
             colspec += " AFTER " + self._get_default_string(
@@ -73,7 +73,7 @@ class ClickHouseDDLCompiler(compiler.DDLCompiler):
         # All columns including synthetic PKs must be 'nullable'
         column.nullable = True
 
-        rv = super(ClickHouseDDLCompiler, self).visit_create_column(
+        rv = super().visit_create_column(
             create, **kw
         )
         column.nullable = nullable
@@ -116,16 +116,16 @@ class ClickHouseDDLCompiler(compiler.DDLCompiler):
         else:
             param = self._compile_param(to_list(param))
 
-        text = '{0}{1}\n'.format(engine.name, param)
+        text = f'{engine.name}{param}\n'
         if engine.partition_by:
-            text += ' PARTITION BY {0}\n'.format(
+            text += ' PARTITION BY {}\n'.format(
                 self._compile_param(
                     engine.partition_by.get_expressions_or_columns(),
                     opt_list=True
                 )
             )
         if engine.order_by:
-            text += ' ORDER BY {0}\n'.format(
+            text += ' ORDER BY {}\n'.format(
                 self._compile_param(
                     engine.order_by.get_expressions_or_columns(),
                     opt_list=True
@@ -133,28 +133,28 @@ class ClickHouseDDLCompiler(compiler.DDLCompiler):
             )
         if engine.primary_key:
             if not engine.order_by:
-                text += ' ORDER BY {0}\n'.format(
+                text += ' ORDER BY {}\n'.format(
                     self._compile_param(
                         engine.primary_key.get_expressions_or_columns(),
                         opt_list=True
                     )
                 )
 
-            text += ' PRIMARY KEY {0}\n'.format(
+            text += ' PRIMARY KEY {}\n'.format(
                 self._compile_param(
                     engine.primary_key.get_expressions_or_columns(),
                     opt_list=True
                 )
             )
         if engine.sample_by:
-            text += ' SAMPLE BY {0}\n'.format(
+            text += ' SAMPLE BY {}\n'.format(
                 self._compile_param(
                     engine.sample_by.get_expressions_or_columns()[0]
                 )
             )
         if engine.ttl:
             compile = self.sql_compiler.process
-            text += ' TTL {0}\n'.format(
+            text += ' TTL {}\n'.format(
                 ',\n     '.join(
                     compile(i, include_table=False, literal_binds=True)
                     for i in engine.ttl.get_expressions_or_columns()
@@ -292,7 +292,7 @@ class ClickHouseDDLCompiler(compiler.DDLCompiler):
         return rv
 
     def visit_set_table_comment(self, create, **kw):
-        return "ALTER TABLE %s MODIFY COMMENT %s" % (
+        return "ALTER TABLE {} MODIFY COMMENT {}".format(
             self.preparer.format_table(create.element),
             self.sql_compiler.render_literal_value(
                 create.element.comment, sqltypes.String()

--- a/clickhouse_sqlalchemy/drivers/compilers/sqlcompiler.py
+++ b/clickhouse_sqlalchemy/drivers/compilers/sqlcompiler.py
@@ -21,7 +21,7 @@ class ClickHouseSQLCompiler(compiler.SQLCompiler):
         ClickHouse does not, so we rely on the `hasAny` array function here.
         """
 
-        return "hasAny([%s], [%s])" % (
+        return "hasAny([{}], [{}])".format(
             self.process(binary.left, **kw),
             self.process(binary.right, **kw),
         )
@@ -32,7 +32,7 @@ class ClickHouseSQLCompiler(compiler.SQLCompiler):
         )
 
     def visit_empty_set_expr(self, element_types):
-        return "SELECT %s WHERE 1!=1" % (
+        return "SELECT {} WHERE 1!=1".format(
             ", ".join(
                 "CAST(NULL AS %s)"
                 % self.dialect.type_compiler.process(
@@ -68,7 +68,7 @@ class ClickHouseSQLCompiler(compiler.SQLCompiler):
         return text
 
     def visit_if__func(self, func, **kw):
-        return "(%s) ? (%s) : (%s)" % (
+        return "({}) ? ({}) : ({})".format(
             self.process(func.clauses.clauses[0], **kw),
             self.process(func.clauses.clauses[1], **kw),
             self.process(func.clauses.clauses[2], **kw)
@@ -223,12 +223,12 @@ class ClickHouseSQLCompiler(compiler.SQLCompiler):
                     from_labeled_label=False,
                     **kw):
         if from_labeled_label:
-            return super(ClickHouseSQLCompiler, self).visit_label(
+            return super().visit_label(
                 label,
                 render_label_as_label=label
             )
         else:
-            return super(ClickHouseSQLCompiler, self).visit_label(
+            return super().visit_label(
                 label,
                 **kw
             )
@@ -464,7 +464,7 @@ class ClickHouseSQLCompiler(compiler.SQLCompiler):
                 ']'
             )
         else:
-            return super(ClickHouseSQLCompiler, self).render_literal_value(
+            return super().render_literal_value(
                 value, type_
             )
 
@@ -475,7 +475,7 @@ class ClickHouseSQLCompiler(compiler.SQLCompiler):
 
     def visit_regexp_match_op_binary(self, binary, operator, **kw):
         string, pattern = self._get_regexp_args(binary, kw)
-        return "MATCH(%s, %s)" % (string, pattern)
+        return f"MATCH({string}, {pattern})"
 
     def visit_not_regexp_match_op_binary(self, binary, operator, **kw):
         return "NOT %s" % self.visit_regexp_match_op_binary(
@@ -488,13 +488,13 @@ class ClickHouseSQLCompiler(compiler.SQLCompiler):
         return element.element._compiler_dispatch(self, **kw)
 
     def visit_ilike_op_binary(self, binary, operator, **kw):
-        return "%s ILIKE %s" % (
+        return "{} ILIKE {}".format(
             self.process(binary.left, **kw),
             self.process(binary.right, **kw)
         )
 
     def visit_not_ilike_op_binary(self, binary, operator, **kw):
-        return "%s NOT ILIKE %s" % (
+        return "{} NOT ILIKE {}".format(
             self.process(binary.left, **kw),
             self.process(binary.right, **kw)
         )

--- a/clickhouse_sqlalchemy/drivers/compilers/typecompiler.py
+++ b/clickhouse_sqlalchemy/drivers/compilers/typecompiler.py
@@ -68,7 +68,7 @@ class ClickHouseTypeCompiler(compiler.GenericTypeCompiler):
 
     def visit_datetime64(self, type_, **kw):
         if type_.timezone:
-            return "DateTime64(%s, '%s')" % (type_.precision, type_.timezone)
+            return f"DateTime64({type_.precision}, '{type_.timezone}')"
         else:
             return 'DateTime64(%s)' % type_.precision
 
@@ -79,7 +79,7 @@ class ClickHouseTypeCompiler(compiler.GenericTypeCompiler):
         return 'Float64'
 
     def visit_numeric(self, type_, **kw):
-        return 'Decimal(%s, %s)' % (type_.precision, type_.scale)
+        return f'Decimal({type_.precision}, {type_.scale})'
 
     def visit_boolean(self, type_, **kw):
         return 'Bool'
@@ -97,7 +97,7 @@ class ClickHouseTypeCompiler(compiler.GenericTypeCompiler):
             "'%s' = %d" %
             (x.name.replace("'", r"\'"), x.value) for x in type_.enum_class
         )
-        return '%s(%s)' % (db_type, ', '.join(choices))
+        return '{}({})'.format(db_type, ', '.join(choices))
 
     def visit_enum(self, type_, **kw):
         return self._render_enum('Enum', type_, **kw)
@@ -127,7 +127,7 @@ class ClickHouseTypeCompiler(compiler.GenericTypeCompiler):
     def visit_map(self, type_, **kw):
         key_type = type_api.to_instance(type_.key_type)
         value_type = type_api.to_instance(type_.value_type)
-        return 'Map(%s, %s)' % (
+        return 'Map({}, {})'.format(
             self.process(key_type, **kw),
             self.process(value_type, **kw)
         )

--- a/clickhouse_sqlalchemy/drivers/http/connector.py
+++ b/clickhouse_sqlalchemy/drivers/http/connector.py
@@ -26,7 +26,7 @@ def connect(*args, **kwargs):
     return Connection(*args, **kwargs)
 
 
-class Connection(object):
+class Connection:
     transport_cls = RequestsTransport
 
     def __init__(self, *args, **kwargs):
@@ -36,7 +36,7 @@ class Connection(object):
 
         # TODO: support `stream` argument in the transport.
         self.transport = self.transport_cls(*args, **kwargs)
-        super(Connection, self).__init__()
+        super().__init__()
 
     def close(self):
         pass
@@ -51,7 +51,7 @@ class Connection(object):
         return Cursor(self)
 
 
-class Cursor(object):
+class Cursor:
     """
     These objects represent a database cursor, which is used to manage
     the context of a fetch operation.
@@ -59,7 +59,7 @@ class Cursor(object):
     Cursors are not isolated, i.e., any changes done to the database
     by a cursor are immediately visible by other cursors or connections.
     """
-    class States(object):
+    class States:
         (
             NONE,
             RUNNING,
@@ -81,7 +81,7 @@ class Cursor(object):
         self._connection = connection
         self._reset_state()
         self._arraysize = 1
-        super(Cursor, self).__init__()
+        super().__init__()
 
     @property
     def rowcount(self):

--- a/clickhouse_sqlalchemy/drivers/http/escaper.py
+++ b/clickhouse_sqlalchemy/drivers/http/escaper.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 import enum
 
 
-class Escaper(object):
+class Escaper:
 
     number_types = (int, float, )
 
@@ -29,7 +29,7 @@ class Escaper(object):
             return "[" + ",".join(
                 [str(self.escape_item(x)) for x in parameters]) + "]"
         else:
-            raise Exception("Unsupported param format: {}".format(parameters))
+            raise Exception(f"Unsupported param format: {parameters}")
 
     def escape_number(self, item):
         return item
@@ -76,4 +76,4 @@ class Escaper(object):
         elif isinstance(item, enum.Enum):
             return self.escape_string(item.name)
         else:
-            raise Exception("Unsupported object {}".format(item))
+            raise Exception(f"Unsupported object {item}")

--- a/clickhouse_sqlalchemy/drivers/http/exceptions.py
+++ b/clickhouse_sqlalchemy/drivers/http/exceptions.py
@@ -1,3 +1,2 @@
-
 class HTTPException(Exception):
     code = None

--- a/clickhouse_sqlalchemy/drivers/http/transport.py
+++ b/clickhouse_sqlalchemy/drivers/http/transport.py
@@ -88,7 +88,7 @@ def _get_type(type_str):
     return None
 
 
-class RequestsTransport(object):
+class RequestsTransport:
 
     def __init__(
             self,
@@ -123,7 +123,7 @@ class RequestsTransport(object):
         http = kwargs.pop('http_session', requests.Session)
         self.http = http() if callable(http) else http
 
-        super(RequestsTransport, self).__init__()
+        super().__init__()
 
     def execute(self, query, params=None):
         """

--- a/clickhouse_sqlalchemy/drivers/native/base.py
+++ b/clickhouse_sqlalchemy/drivers/native/base.py
@@ -24,7 +24,7 @@ class ClickHouseExecutionContext(ClickHouseExecutionContextBase):
 class ClickHouseNativeSQLCompiler(ClickHouseSQLCompiler):
 
     def visit_insert(self, insert_stmt, asfrom=False, **kw):
-        rv = super(ClickHouseNativeSQLCompiler, self).visit_insert(
+        rv = super().visit_insert(
             insert_stmt, asfrom=asfrom, **kw)
 
         if kw.get('literal_binds') or insert_stmt._values:

--- a/clickhouse_sqlalchemy/drivers/native/connector.py
+++ b/clickhouse_sqlalchemy/drivers/native/connector.py
@@ -28,13 +28,13 @@ def connect(*args, **kwargs):
     return Connection(*args, **kwargs)
 
 
-class Connection(object):
+class Connection:
     transport_cls = DriverClient
 
     def __init__(self, *args, **kwargs):
         url = args[0]
         self.transport = self.transport_cls.from_url(url)
-        super(Connection, self).__init__()
+        super().__init__()
 
     def close(self):
         pass
@@ -49,7 +49,7 @@ class Connection(object):
         return Cursor(self)
 
 
-class Cursor(object):
+class Cursor:
     """
     These objects represent a database cursor, which is used to manage
     the context of a fetch operation.
@@ -57,7 +57,7 @@ class Cursor(object):
     Cursors are not isolated, i.e., any changes done to the database
     by a cursor are immediately visible by other cursors or connections.
     """
-    class States(object):
+    class States:
         (
             NONE,
             RUNNING,
@@ -70,7 +70,7 @@ class Cursor(object):
         self._connection = connection
         self._reset_state()
         self._arraysize = 1
-        super(Cursor, self).__init__()
+        super().__init__()
 
     @property
     def rowcount(self):

--- a/clickhouse_sqlalchemy/drivers/reflection.py
+++ b/clickhouse_sqlalchemy/drivers/reflection.py
@@ -15,7 +15,7 @@ class ClickHouseInspector(reflection.Inspector):
         else:
             ch_table = table
 
-        super(ClickHouseInspector, self).reflect_table(
+        super().reflect_table(
             ch_table, *args, **kwargs
         )
 

--- a/clickhouse_sqlalchemy/drivers/util.py
+++ b/clickhouse_sqlalchemy/drivers/util.py
@@ -1,4 +1,3 @@
-
 def get_inner_spec(spec):
     brackets = 0
     offset = spec.find('(')

--- a/clickhouse_sqlalchemy/engines/__init__.py
+++ b/clickhouse_sqlalchemy/engines/__init__.py
@@ -1,4 +1,3 @@
-
 from .mergetree import (
     MergeTree, AggregatingMergeTree, GraphiteMergeTree, CollapsingMergeTree,
     VersionedCollapsingMergeTree, ReplacingMergeTree, SummingMergeTree

--- a/clickhouse_sqlalchemy/engines/base.py
+++ b/clickhouse_sqlalchemy/engines/base.py
@@ -35,7 +35,7 @@ class Engine(Constraint):
 
 class TableCol(ColumnCollectionMixin, SchemaItem):
     def __init__(self, column, **kwargs):
-        super(TableCol, self).__init__(*[column], **kwargs)
+        super().__init__(*[column], **kwargs)
 
     def get_column(self):
         return list(self.columns)[0]
@@ -45,7 +45,7 @@ class KeysExpressionOrColumn(ColumnCollectionMixin, SchemaItem):
     def __init__(self, *expressions, **kwargs):
         self.expressions = []
 
-        super(KeysExpressionOrColumn, self).__init__(
+        super().__init__(
             *expressions, _gather_expressions=self.expressions, **kwargs
         )
 

--- a/clickhouse_sqlalchemy/engines/mergetree.py
+++ b/clickhouse_sqlalchemy/engines/mergetree.py
@@ -39,10 +39,10 @@ class MergeTree(Engine):
             self.ttl = KeysExpressionOrColumn(*to_list(ttl))
 
         self.settings = settings
-        super(MergeTree, self).__init__()
+        super().__init__()
 
     def _set_parent(self, table, **kwargs):
-        super(MergeTree, self)._set_parent(table, **kwargs)
+        super()._set_parent(table, **kwargs)
         if self.partition_by is not None:
             self.partition_by._set_parent(table, **kwargs)
         if self.order_by is not None:
@@ -94,11 +94,11 @@ class AggregatingMergeTree(MergeTree):
 class GraphiteMergeTree(MergeTree):
 
     def __init__(self, config_name, *args, **kwargs):
-        super(GraphiteMergeTree, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.config_name = config_name
 
     def get_parameters(self):
-        return "'{}'".format(self.config_name)
+        return f"'{self.config_name}'"
 
     @classmethod
     def reflect(cls, table, engine_full, **kwargs):
@@ -113,14 +113,14 @@ class GraphiteMergeTree(MergeTree):
 
 class CollapsingMergeTree(MergeTree):
     def __init__(self, sign_col, *args, **kwargs):
-        super(CollapsingMergeTree, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.sign_col = TableCol(sign_col)
 
     def get_parameters(self):
         return self.sign_col.get_column()
 
     def _set_parent(self, table, **kwargs):
-        super(CollapsingMergeTree, self)._set_parent(table, **kwargs)
+        super()._set_parent(table, **kwargs)
 
         self.sign_col._set_parent(table, **kwargs)
 
@@ -137,7 +137,7 @@ class CollapsingMergeTree(MergeTree):
 
 class VersionedCollapsingMergeTree(MergeTree):
     def __init__(self, sign_col, version_col, *args, **kwargs):
-        super(VersionedCollapsingMergeTree, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.sign_col = TableCol(sign_col)
         self.version_col = TableCol(version_col)
@@ -146,7 +146,7 @@ class VersionedCollapsingMergeTree(MergeTree):
         return [self.sign_col.get_column(), self.version_col.get_column()]
 
     def _set_parent(self, table, **kwargs):
-        super(VersionedCollapsingMergeTree, self)._set_parent(table, **kwargs)
+        super()._set_parent(table, **kwargs)
 
         self.sign_col._set_parent(table, **kwargs)
         self.version_col._set_parent(table, **kwargs)
@@ -166,14 +166,14 @@ class VersionedCollapsingMergeTree(MergeTree):
 class SummingMergeTree(MergeTree):
     def __init__(self, *args, **kwargs):
         summing_cols = kwargs.pop('columns', None)
-        super(SummingMergeTree, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.summing_cols = None
         if summing_cols is not None:
             self.summing_cols = KeysExpressionOrColumn(*to_list(summing_cols))
 
     def _set_parent(self, table, **kwargs):
-        super(SummingMergeTree, self)._set_parent(table, **kwargs)
+        super()._set_parent(table, **kwargs)
 
         if self.summing_cols is not None:
             self.summing_cols._set_parent(table, **kwargs)
@@ -198,14 +198,14 @@ class SummingMergeTree(MergeTree):
 class ReplacingMergeTree(MergeTree):
     def __init__(self, *args, **kwargs):
         version_col = kwargs.pop('version', None)
-        super(ReplacingMergeTree, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.version_col = None
         if version_col is not None:
             self.version_col = TableCol(version_col)
 
     def _set_parent(self, table, **kwargs):
-        super(ReplacingMergeTree, self)._set_parent(table, **kwargs)
+        super()._set_parent(table, **kwargs)
 
         if self.version_col is not None:
             self.version_col._set_parent(table, **kwargs)

--- a/clickhouse_sqlalchemy/engines/misc.py
+++ b/clickhouse_sqlalchemy/engines/misc.py
@@ -1,4 +1,3 @@
-
 from .base import Engine
 from .util import parse_columns
 
@@ -9,7 +8,7 @@ class Distributed(Engine):
         self.default = default
         self.hits = hits
         self.sharding_key = sharding_key
-        super(Distributed, self).__init__()
+        super().__init__()
 
     def get_parameters(self):
         params = [
@@ -45,7 +44,7 @@ class Buffer(Engine):
         self.max_rows = max_rows
         self.min_bytes = min_bytes
         self.max_bytes = max_bytes
-        super(Buffer, self).__init__()
+        super().__init__()
 
     def get_parameters(self):
         return [
@@ -134,12 +133,12 @@ class File(Engine):
         fmt = self.supported_data_formats.get(data_format.lower())
         if not fmt:
             raise ValueError(
-                'Format {0} not supported for File engine'.format(
+                'Format {} not supported for File engine'.format(
                     data_format
                 )
             )
         self.data_format = fmt
-        super(File, self).__init__()
+        super().__init__()
 
     def get_parameters(self):
         return (self.data_format, )

--- a/clickhouse_sqlalchemy/engines/replicated.py
+++ b/clickhouse_sqlalchemy/engines/replicated.py
@@ -5,15 +5,15 @@ from .mergetree import (
 from .util import parse_columns
 
 
-class ReplicatedEngineMixin(object):
+class ReplicatedEngineMixin:
     def __init__(self, table_path, replica_name):
         self.table_path = table_path
         self.replica_name = replica_name
 
     def get_parameters(self):
         return [
-            "'{}'".format(self.table_path),
-            "'{}'".format(self.replica_name)
+            f"'{self.table_path}'",
+            f"'{self.replica_name}'"
         ]
 
     @classmethod

--- a/clickhouse_sqlalchemy/engines/util.py
+++ b/clickhouse_sqlalchemy/engines/util.py
@@ -1,5 +1,3 @@
-
-
 def parse_columns(str_columns, delimeter=',', quote_symbol='`',
                   escape_symbol='\\'):
     if not str_columns:

--- a/clickhouse_sqlalchemy/exceptions.py
+++ b/clickhouse_sqlalchemy/exceptions.py
@@ -1,9 +1,7 @@
-
-
 class DatabaseException(Exception):
     def __init__(self, orig):
         self.orig = orig
-        super(DatabaseException, self).__init__(orig)
+        super().__init__(orig)
 
     def __str__(self):
-        return 'Orig exception: {}'.format(self.orig)
+        return f'Orig exception: {self.orig}'

--- a/clickhouse_sqlalchemy/ext/declarative.py
+++ b/clickhouse_sqlalchemy/ext/declarative.py
@@ -30,7 +30,7 @@ class ClickHouseDeclarativeMeta(DeclarativeMeta):
             def _join(match):
                 word = match.group()
                 if len(word) > 1:
-                    return ('_%s_%s' % (word[:-1], word[-1])).lower()
+                    return (f'_{word[:-1]}_{word[-1]}').lower()
                 return '_' + word.lower()
             d['__tablename__'] = cls._camelcase_re.sub(_join, name).lstrip('_')
 

--- a/clickhouse_sqlalchemy/orm/__init__.py
+++ b/clickhouse_sqlalchemy/orm/__init__.py
@@ -1,4 +1,3 @@
-
 from .session import make_session
 
 

--- a/clickhouse_sqlalchemy/orm/query.py
+++ b/clickhouse_sqlalchemy/orm/query.py
@@ -20,7 +20,7 @@ class Query(BaseQuery):
     _array_join = None
 
     def _compile_context(self, *args, **kwargs):
-        context = super(Query, self)._compile_context(*args, **kwargs)
+        context = super()._compile_context(*args, **kwargs)
         query = context.query
 
         query._with_cube = self._with_cube

--- a/clickhouse_sqlalchemy/sql/__init__.py
+++ b/clickhouse_sqlalchemy/sql/__init__.py
@@ -1,4 +1,3 @@
-
 from .schema import Table, MaterializedView
 from .selectable import Select, select
 

--- a/clickhouse_sqlalchemy/sql/ddl.py
+++ b/clickhouse_sqlalchemy/sql/ddl.py
@@ -9,20 +9,19 @@ from sqlalchemy.sql.operators import custom_op
 class DropTable(DropTableBase):
     def __init__(self, element, bind=None, if_exists=False):
         self.on_cluster = element.dialect_options['clickhouse']['cluster']
-        super(DropTable, self).__init__(element,
-                                        if_exists=if_exists)
+        super().__init__(element, if_exists=if_exists)
 
 
 class DropView(DropTableBase):
     def __init__(self, element, bind=None, if_exists=False):
         self.on_cluster = element.cluster
-        super(DropView, self).__init__(element, if_exists=if_exists)
+        super().__init__(element, if_exists=if_exists)
 
 
 class SchemaDropper(SchemaDropperBase):
     def __init__(self, dialect, connection, if_exists=False, **kwargs):
         self.if_exists = if_exists
-        super(SchemaDropper, self).__init__(dialect, connection, **kwargs)
+        super().__init__(dialect, connection, **kwargs)
 
     def visit_table(self, table, **kwargs):
         table.dispatch.before_drop(
@@ -52,13 +51,13 @@ class CreateMaterializedView(_CreateDropBase):
 
     def __init__(self, element, if_not_exists=False):
         self.if_not_exists = if_not_exists
-        super(CreateMaterializedView, self).__init__(element)
+        super().__init__(element)
 
 
 class SchemaGenerator(SchemaGeneratorBase):
     def __init__(self, dialect, connection, if_not_exists=False, **kwargs):
         self.if_not_exists = if_not_exists
-        super(SchemaGenerator, self).__init__(dialect, connection, **kwargs)
+        super().__init__(dialect, connection, **kwargs)
 
     def visit_materialized_view(self, table, **kwargs):
         self.connection.execute(

--- a/clickhouse_sqlalchemy/sql/schema.py
+++ b/clickhouse_sqlalchemy/sql/schema.py
@@ -108,7 +108,7 @@ class MaterializedView(DialectKWArgs, SchemaItem, Immutable, FromClause):
             args += (
                 [repr(x) for x in self.inner_table.columns]
                 + [repr(self.inner_table.engine)]
-                + ['%s=%s' % (k, repr(getattr(self, k))) for k in ['schema']]
+                + [f'{k}={repr(getattr(self, k))}' for k in ['schema']]
             )
 
         args += ['AS ' + str(self.mv_selectable)]

--- a/clickhouse_sqlalchemy/types/common.py
+++ b/clickhouse_sqlalchemy/types/common.py
@@ -6,7 +6,7 @@ class ClickHouseTypeEngine(types.TypeEngine):
     def compile(self, dialect=None):
         from clickhouse_sqlalchemy.drivers.base import clickhouse_dialect
 
-        return super(ClickHouseTypeEngine, self).compile(
+        return super().compile(
             dialect=clickhouse_dialect
         )
 
@@ -35,7 +35,7 @@ class Array(ClickHouseTypeEngine):
     def __init__(self, item_type):
         self.item_type = item_type
         self.item_type_impl = to_instance(item_type)
-        super(Array, self).__init__()
+        super().__init__()
 
     @property
     def python_type(self):
@@ -59,7 +59,7 @@ class Nullable(ClickHouseTypeEngine):
 
     def __init__(self, nested_type):
         self.nested_type = to_instance(nested_type)
-        super(Nullable, self).__init__()
+        super().__init__()
 
 
 class UUID(String):
@@ -71,7 +71,7 @@ class LowCardinality(ClickHouseTypeEngine):
 
     def __init__(self, nested_type):
         self.nested_type = to_instance(nested_type)
-        super(LowCardinality, self).__init__()
+        super().__init__()
 
 
 class Int8(Int):
@@ -138,7 +138,7 @@ class DateTime(types.DateTime, ClickHouseTypeEngine):
     __visit_name__ = 'datetime'
 
     def __init__(self, timezone=None):
-        super(DateTime, self).__init__()
+        super().__init__()
         self.timezone = timezone
 
 
@@ -147,7 +147,7 @@ class DateTime64(DateTime, ClickHouseTypeEngine):
 
     def __init__(self, precision=3, timezone=None):
         self.precision = precision
-        super(DateTime64, self).__init__(timezone=timezone)
+        super().__init__(timezone=timezone)
 
 
 class Enum(types.Enum, ClickHouseTypeEngine):
@@ -158,7 +158,7 @@ class Enum(types.Enum, ClickHouseTypeEngine):
         if not enums:
             enums = kw.get('_enums', ())  # passed as keyword
 
-        super(Enum, self).__init__(*enums, **kw, convert_unicode=False)
+        super().__init__(*enums, **kw, convert_unicode=False)
 
 
 class Enum8(Enum):
@@ -178,7 +178,7 @@ class Tuple(ClickHouseTypeEngine):
 
     def __init__(self, *nested_types):
         self.nested_types = nested_types
-        super(Tuple, self).__init__()
+        super().__init__()
 
 
 class Map(ClickHouseTypeEngine):
@@ -187,4 +187,4 @@ class Map(ClickHouseTypeEngine):
     def __init__(self, key_type, value_type):
         self.key_type = key_type
         self.value_type = value_type
-        super(Map, self).__init__()
+        super().__init__()

--- a/clickhouse_sqlalchemy/types/ip.py
+++ b/clickhouse_sqlalchemy/types/ip.py
@@ -31,7 +31,7 @@ class BaseIPComparator(UserDefinedType.Comparator):
     def in_(self, other):
         if isinstance(other, (list, tuple)):
             addresses, networks = self._split_other(other)
-            addresses_clause = super(BaseIPComparator, self).in_(
+            addresses_clause = super().in_(
                 self._wrap_to_ip(x) for x in addresses
             ) if addresses else None
             networks_clause = or_(*[
@@ -49,7 +49,7 @@ class BaseIPComparator(UserDefinedType.Comparator):
                 return networks_clause
             else:
                 # other is an empty array
-                return super(BaseIPComparator, self).in_(other)
+                return super().in_(other)
 
         if not isinstance(other, self.network_class):
             other = self.network_class(other)
@@ -62,7 +62,7 @@ class BaseIPComparator(UserDefinedType.Comparator):
     def not_in(self, other):
         if isinstance(other, (list, tuple)):
             addresses, networks = self._split_other(other)
-            addresses_clause = super(BaseIPComparator, self).notin_(
+            addresses_clause = super().notin_(
                 self._wrap_to_ip(x) for x in addresses
             ) if addresses else None
             networks_clause = and_(*[
@@ -80,7 +80,7 @@ class BaseIPComparator(UserDefinedType.Comparator):
                 return networks_clause
             else:
                 # other is an empty array
-                return super(BaseIPComparator, self).notin_(other)
+                return super().notin_(other)
 
         if not isinstance(other, self.network_class):
             other = self.network_class(other)

--- a/clickhouse_sqlalchemy/types/nested.py
+++ b/clickhouse_sqlalchemy/types/nested.py
@@ -14,7 +14,7 @@ class Nested(types.TypeEngine):
             raise ValueError('columns must be specified for nested type')
         self.columns = columns
         self._columns_dict = {col.name: col for col in columns}
-        super(Nested, self).__init__()
+        super().__init__()
 
     class Comparator(UserDefinedType.Comparator):
         def __getattr__(self, key):
@@ -43,7 +43,7 @@ class NestedColumn(ColumnClause):
             table = self.parent.element.table
         else:
             table = self.parent.table
-        super(NestedColumn, self).__init__(
+        super().__init__(
             sub_column.name,
             sub_column.type,
             _selectable=table
@@ -55,7 +55,7 @@ def _comp(element, compiler, **kw):
     from_labeled_label = False
     if isinstance(element.parent, Label):
         from_labeled_label = True
-    return "%s.%s" % (
+    return "{}.{}".format(
         compiler.process(element.parent,
                          from_labeled_label=from_labeled_label,
                          within_label_clause=False,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Configuration file for the Sphinx documentation builder.
 #

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def read_version():
 
 
 dialects = [
-    'clickhouse{}=clickhouse_sqlalchemy.drivers.{}'.format(driver, d_path)
+    f'clickhouse{driver}=clickhouse_sqlalchemy.drivers.{d_path}'
 
     for driver, d_path in [
         ('', 'http.base:ClickHouseDialect_http'),

--- a/tests/drivers/http/test_select.py
+++ b/tests/drivers/http/test_select.py
@@ -13,7 +13,7 @@ class FormatSectionTestCase(HttpSessionTestCase):
     def _compile(self, clause, bind=None, **kwargs):
         if bind is None:
             bind = self.session.bind
-        statement = super(FormatSectionTestCase, self)._compile(
+        statement = super()._compile(
             clause, bind=bind, **kwargs
         )
 

--- a/tests/drivers/http/test_transport.py
+++ b/tests/drivers/http/test_transport.py
@@ -13,7 +13,7 @@ from tests.testcase import HttpSessionTestCase
 class TransportCase(HttpSessionTestCase):
     @property
     def url(self):
-        return 'http://{host}:{port}'.format(host=self.host, port=self.port)
+        return f'http://{self.host}:{self.port}'
 
     @mock.activate
     def test_parse_func_count(self):

--- a/tests/drivers/http/test_utils.py
+++ b/tests/drivers/http/test_utils.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 from clickhouse_sqlalchemy.drivers.http.utils import unescape, parse_tsv
 from tests.testcase import BaseTestCase
 

--- a/tests/drivers/native/test_base.py
+++ b/tests/drivers/native/test_base.py
@@ -52,7 +52,7 @@ class TestConnectArgs(BaseTestCase):
     def test_quoting(self):
         user = quote('us#er')
         password = quote(' pass#word')
-        part = '{}:{}@host/database'.format(user, password)
+        part = f'{user}:{password}@host/database'
         url = make_url('clickhouse+native://' + part)
         connect_args = self.dialect.create_connect_args(url)
         self.assertEqual(

--- a/tests/drivers/test_clickhouse_dialect.py
+++ b/tests/drivers/test_clickhouse_dialect.py
@@ -25,7 +25,7 @@ class ClickHouseDialectTestCase(BaseTestCase):
         return self.session.connection()
 
     def setUp(self):
-        super(ClickHouseDialectTestCase, self).setUp()
+        super().setUp()
         self.table = Table(
             'test_exists_table',
             self.metadata(),
@@ -44,7 +44,7 @@ class ClickHouseDialectTestCase(BaseTestCase):
 
     def tearDown(self):
         self.table.drop(self.session.bind, if_exists=True)
-        super(ClickHouseDialectTestCase, self).tearDown()
+        super().tearDown()
 
     def test_has_table(self):
         self.assertFalse(

--- a/tests/engines/test_reflection.py
+++ b/tests/engines/test_reflection.py
@@ -210,7 +210,7 @@ class EngineReflectionTestCase(BaseTestCase):
     def test_disable_engine_reflection(self):
         engine = self.session.connection().engine
         url = engine.url.render_as_string(hide_password=False)
-        prefix = 'clickhouse+{}://'.format(engine.driver)
+        prefix = f'clickhouse+{engine.driver}://'
         if not url.startswith(prefix):
             url = prefix + url.split('://')[1]
 

--- a/tests/orm/test_select.py
+++ b/tests/orm/test_select.py
@@ -262,12 +262,12 @@ class SelectTestCase(CompilationTestCase):
 
 class JoinTestCase(CompilationTestCase):
     def test_joins(self):
-        t1, t2 = [Table(
-            't{}'.format(i), self.metadata(),
+        t1, t2 = (Table(
+            f't{i}', self.metadata(),
             Column('x', types.Int32, primary_key=True),
             Column('y', types.Int32, primary_key=True),
             engines.Memory()
-        ) for i in range(1, 3)]
+        ) for i in range(1, 3))
 
         query = self.session.query(t1.c.x, t2.c.x) \
             .join(
@@ -364,12 +364,12 @@ class JoinTestCase(CompilationTestCase):
         )
 
     def test_multiple_joins(self):
-        t1, t2, t3 = [Table(
-            't{}'.format(i), self.metadata(),
+        t1, t2, t3 = (Table(
+            f't{i}', self.metadata(),
             Column('x', types.Int32, primary_key=True),
             Column('y', types.Int32, primary_key=True),
             engines.Memory()
-        ) for i in range(1, 4)]
+        ) for i in range(1, 4))
 
         query = self.session.query(t1.c.x, t2.c.x) \
             .join(t2, t1.c.x == t2.c.y, strictness='any') \

--- a/tests/session.py
+++ b/tests/session.py
@@ -22,7 +22,7 @@ system_asynch_session = make_session(
 )
 
 
-class MockedEngine(object):
+class MockedEngine:
 
     prev_do_execute = None
     prev_do_executemany = None

--- a/tests/sql/test_is_distinct_from.py
+++ b/tests/sql/test_is_distinct_from.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 from parameterized import parameterized
 from sqlalchemy import select, literal
 
@@ -16,7 +14,7 @@ class IsDistinctFromTestCase(BaseTestCase):
         (1, 2),
         (1, None),
         (None, "NULL"),
-        (None, u"ᴺᵁᴸᴸ"),
+        (None, "ᴺᵁᴸᴸ"),
         ((1, None), (2, None)),
         ((1, (1, None)), (1, (2, None)))
     ])

--- a/tests/testcase.py
+++ b/tests/testcase.py
@@ -11,7 +11,7 @@ from tests.session import http_session, native_session, \
 from tests.util import skip_by_server_version, run_async
 
 
-class BaseAbstractTestCase(object):
+class BaseAbstractTestCase:
     """ Supporting code for tests """
     required_server_version = None
     server_version = None
@@ -71,10 +71,10 @@ class BaseTestCase(BaseAbstractTestCase, TestCase):
     def setUpClass(cls):
         # System database is always present.
         system_native_session.execute(
-            text('DROP DATABASE IF EXISTS {}'.format(cls.database))
+            text(f'DROP DATABASE IF EXISTS {cls.database}')
         )
         system_native_session.execute(
-            text('CREATE DATABASE {}'.format(cls.database))
+            text(f'CREATE DATABASE {cls.database}')
         )
 
         version = system_native_session.execute(
@@ -85,7 +85,7 @@ class BaseTestCase(BaseAbstractTestCase, TestCase):
         super().setUpClass()
 
     def setUp(self):
-        super(BaseTestCase, self).setUp()
+        super().setUp()
 
         required = self.required_server_version
 
@@ -101,10 +101,10 @@ class BaseAsynchTestCase(BaseTestCase):
     async def setUpClass(cls):
         # System database is always present.
         await system_asynch_session.execute(
-            text('DROP DATABASE IF EXISTS {}'.format(cls.database))
+            text(f'DROP DATABASE IF EXISTS {cls.database}')
         )
         await system_asynch_session.execute(
-            text('CREATE DATABASE {}'.format(cls.database))
+            text(f'CREATE DATABASE {cls.database}')
         )
 
         version = (
@@ -174,7 +174,7 @@ class CompilationTestCase(BaseTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(CompilationTestCase, cls).setUpClass()
+        super().setUpClass()
 
         cls._session_connection = cls.session.connection
         cls._session_execute = cls.session.execute
@@ -187,4 +187,4 @@ class CompilationTestCase(BaseTestCase):
         cls.session.execute = cls._session_execute
         cls.session.connection = cls._session_connection
 
-        super(CompilationTestCase, cls).tearDownClass()
+        super().tearDownClass()

--- a/testsrequire.py
+++ b/testsrequire.py
@@ -1,4 +1,3 @@
-
 tests_require = [
     'pytest',
     'sqlalchemy>=2.0.0,<2.1.0',


### PR DESCRIPTION
Hello,

The code seems to use python 2 conventions. I propose that we update these syntaxes to the new one introduced with python 3.7, as it is currently the minimal version supported by clickhouse-sqlalchemy (even if the official minimum python version is currently 3.8, see [the official status](https://devguide.python.org/versions/#python-release-cycle))

To generate this PR I run pyupgrade on the full code.

Please let me know:

- if you are interested in this action, or if you prefer to keep the current syntax for some reasons
- if you wish to add pyupgrade to the CI to automatically detect old python syntax
- if you wish to update the CI to remove python 3.7 support

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [x] Run `flake8` and fix issues.
- [x] Run `pytest` no tests failed. See https://clickhouse-sqlalchemy.readthedocs.io/en/latest/development.html.
