### PR TITLE
GitHub action improvement

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -2,7 +2,7 @@ on: [push, pull_request]
 name: build
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version:
@@ -17,20 +17,30 @@ jobs:
           - 22.5.1.2079
           - 19.3.5
           - 18.14.9
+        include:
+          - clickhouse-version: 18.14.9
+            clickhouse-org: yandex
+          - clickhouse-version: 19.3.5
+            clickhouse-org: yandex
+          - clickhouse-version: 22.5.1.2079
+            clickhouse-org: clickhouse
+          - clickhouse-version: 23.8.4.69
+            clickhouse-org: clickhouse
+    services:
+      clickhouse-server:
+        image: ${{ matrix.clickhouse-org }}/clickhouse-server:${{ matrix.clickhouse-version }}
+        ports:
+          - 8123:8123
+          - 9000:9000
 
     name: ${{ matrix.python-version }} CH=${{ matrix.clickhouse-version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-#      - name: Login to Docker Hub
-#        uses: docker/login-action@v1
-#        with:
-#          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-#          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: Install test requirements
         run: |
           pip install --upgrade pip setuptools wheel
@@ -41,26 +51,9 @@ jobs:
           pip install pytest-timeout
       - name: Run flake8
         run: flake8
-      - name: Setup /etc/hosts
-        run: |
-          # Overriding setup.cfg. Set host=clickhouse-server
-          sed -i 's/^host=localhost$/host=clickhouse-server/' setup.cfg
-          # Make host think that clickhouse-server is localhost
-          echo '127.0.0.1 clickhouse-server' | sudo tee /etc/hosts > /dev/null
-      - name: Start ClickHouse server container
-        run: |
-          echo "VERSION=${{ matrix.clickhouse-version }}" > tests/.env
-          if [[ "${{ matrix.clickhouse-version }}" > "21.7" ]]; then echo "ORG=clickhouse"; else echo "ORG=yandex" ; fi  >> tests/.env
-          docker-compose -f tests/docker-compose.yml up -d
       - name: Run tests
         run: coverage run --source=clickhouse_sqlalchemy -m pytest --timeout=10 -v
         timeout-minutes: 2
-      - name: Set up Python for coverage submission
-        if: ${{ matrix.python-version == '2.7' }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-          architecture: x64
       - name: Install coveralls
         run: |
           # Newer coveralls do not work with github actions.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,14 +2,14 @@ on: [push, pull_request]
 name: build-docs
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Build docs
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.11
+          python-version: 3.12
           architecture: x64
       - name: Update tools
         run: pip install --upgrade pip setuptools wheel

--- a/.github/workflows/sa-versions.yml
+++ b/.github/workflows/sa-versions.yml
@@ -10,20 +10,21 @@ jobs:
         clickhouse-version:
           - 23.8.4.69
         sa-version: [18, 19, 20, 21, 22]
+    services:
+      clickhouse-server:
+        image: clickhouse/clickhouse-server:${{ matrix.clickhouse-version }}
+        ports:
+          - 8123:8123
+          - 9000:9000
 
     name: ${{ matrix.python-version }} SA=2.0.${{ matrix.sa-version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-#      - name: Login to Docker Hub
-#        uses: docker/login-action@v1
-#        with:
-#          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-#          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: Install test requirements
         run: |
           pip install --upgrade pip setuptools wheel
@@ -33,17 +34,6 @@ jobs:
           pip install pytest-timeout
       - name: Install SQLAlchemy
         run: pip install sqlalchemy==2.0.${{ matrix.sa-version }}
-      - name: Setup /etc/hosts
-        run: |
-          # Overriding setup.cfg. Set host=clickhouse-server
-          sed -i 's/^host=localhost$/host=clickhouse-server/' setup.cfg
-          # Make host think that clickhouse-server is localhost
-          echo '127.0.0.1 clickhouse-server' | sudo tee /etc/hosts > /dev/null
-      - name: Start ClickHouse server container
-        run: |
-          echo "VERSION=${{ matrix.clickhouse-version }}" > tests/.env
-          if [[ "${{ matrix.clickhouse-version }}" > "21.7" ]]; then echo "ORG=clickhouse"; else echo "ORG=yandex" ; fi  >> tests/.env
-          docker-compose -f tests/docker-compose.yml up -d
       - name: Run tests
         run: pytest --timeout=10 -v
         timeout-minutes: 2

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -41,29 +41,11 @@ Create container desired version of ``clickhouse-server``:
 
         docker run --rm -p 127.0.0.1:9000:9000 -p 127.0.0.1:8123:8123 --name test-clickhouse-server clickhouse/clickhouse-server:$VERSION
 
-Create container with the same version of ``clickhouse-client``:
+Or run the docker-compose defined in tests folder:
 
     .. code-block:: bash
 
-        docker run --rm --entrypoint "/bin/sh" --name test-clickhouse-client --link test-clickhouse-server:clickhouse-server clickhouse/clickhouse-client:$VERSION -c 'while :; do sleep 1; done'
-
-Create ``clickhouse-client`` script on your host machine:
-
-    .. code-block:: bash
-
-        echo -e '#!/bin/bash\n\ndocker exec test-clickhouse-client clickhouse-client "$@"' | sudo tee /usr/local/bin/clickhouse-client > /dev/null
-        sudo chmod +x /usr/local/bin/clickhouse-client
-
-After it container ``test-clickhouse-client`` will communicate with
-``test-clickhouse-server`` transparently from host machine.
-
-Set ``host=clickhouse-server`` in ``setup.cfg``.
-
-Add entry in hosts file:
-
-    .. code-block:: bash
-
-        echo '127.0.0.1 clickhouse-server' | sudo tee -a /etc/hosts > /dev/null
+        cd tests && docker compose up -d
 
 And run tests:
 


### PR DESCRIPTION
Hello !

I would like to propose some change to the github actions to use the `services` capabilities to start the clickhouse server instead of hacking the setup.cfg and the host network. I also updated the doc to reflect this change.

What do you think ?

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [ ] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [ ] Run `flake8` and fix issues.
- [x] Run `pytest` no tests failed. See https://clickhouse-sqlalchemy.readthedocs.io/en/latest/development.html.
