### PR TITLE
Fixed adding a duplicate column to the alembic table

### DIFF
--- a/clickhouse_sqlalchemy/alembic/dialect.py
+++ b/clickhouse_sqlalchemy/alembic/dialect.py
@@ -43,7 +43,7 @@ def patch_alembic_version(context, **kwargs):
     dt = Column('dt', types.DateTime, server_default=func.now())
     version_num = Column('version_num', types.String, primary_key=True)
     version.append_column(dt)
-    version.append_column(version_num)
+    version.append_column(version_num, replace_existing=True)
 
     if 'cluster' in kwargs:
         cluster = kwargs['cluster']


### PR DESCRIPTION
Fix problem with new sqlalchemy for alembic migrations. 

What changed?
- old sqlalchemy function `table.append_column` [link](https://github.com/sqlalchemy/sqlalchemy/blob/5e88e6e89a2cf5b583670fa5d0b41881f895a711/lib/sqlalchemy/sql/schema.py#L1057)
- new sqlalchemy function `table.append_column` [link](https://github.com/sqlalchemy/sqlalchemy/blob/main/lib/sqlalchemy/sql/schema.py#L1213) 

> replace_existing: When ``True``, allows replacing existing
    columns. When ``False``, the default, an warning will be raised
    if a column with the same ``.key`` already exists. **A future
    version of sqlalchemy will instead rise a warning.**

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [ ] Run `flake8` and fix issues.
- [ ] Run `pytest` no tests failed. See https://clickhouse-sqlalchemy.readthedocs.io/en/latest/development.html.
