### PR TITLE
fix visit_regexp_match_op_binary to use the correct function name

### DIFF
--- a/clickhouse_sqlalchemy/drivers/compilers/sqlcompiler.py
+++ b/clickhouse_sqlalchemy/drivers/compilers/sqlcompiler.py
@@ -475,7 +475,7 @@ class ClickHouseSQLCompiler(compiler.SQLCompiler):
 
     def visit_regexp_match_op_binary(self, binary, operator, **kw):
         string, pattern = self._get_regexp_args(binary, kw)
-        return "MATCH(%s, %s)" % (string, pattern)
+        return "match(%s, %s)" % (string, pattern)
 
     def visit_not_regexp_match_op_binary(self, binary, operator, **kw):
         return "NOT %s" % self.visit_regexp_match_op_binary(

--- a/tests/sql/test_regexp_match.py
+++ b/tests/sql/test_regexp_match.py
@@ -20,7 +20,7 @@ class RegexpMatch(BaseTestCase):
 
         self.assertEqual(
             self.compile(query, literal_binds=True),
-            "SELECT t1.x AS t1_x FROM t1 WHERE MATCH(t1.y, '^s.*')"
+            "SELECT t1.x AS t1_x FROM t1 WHERE match(t1.y, '^s.*')"
         )
 
     def test_not_regex_match(self):
@@ -31,5 +31,5 @@ class RegexpMatch(BaseTestCase):
 
         self.assertEqual(
             self.compile(query, literal_binds=True),
-            "SELECT t1.x AS t1_x FROM t1 WHERE NOT MATCH(t1.y, '^s.*')"
+            "SELECT t1.x AS t1_x FROM t1 WHERE NOT match(t1.y, '^s.*')"
         )


### PR DESCRIPTION
MATCH raises an error `Unknown function MATCH. Maybe you meant: ['match','path']`

https://clickhouse.com/docs/en/sql-reference/functions/string-search-functions#match

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [x] Run `flake8` and fix issues.
- [x] Run `pytest` no tests failed. See https://clickhouse-sqlalchemy.readthedocs.io/en/latest/development.html.
