### PR TITLE
fix: fix select.join

### DIFF
--- a/clickhouse_sqlalchemy/sql/selectable.py
+++ b/clickhouse_sqlalchemy/sql/selectable.py
@@ -1,7 +1,6 @@
 from sqlalchemy.sql.base import _generative
 from sqlalchemy.sql.selectable import (
     Select as StandardSelect,
-    Join
 )
 
 from ..ext.clauses import (
@@ -77,8 +76,8 @@ class Select(StandardSelect):
             'strictness': strictness,
             'distribution': distribution
         }
-        return Join(self, right, onclause=onclause, isouter=isouter,
-                    full=flags)
+        return super().join(right, onclause=onclause, isouter=isouter,
+                            full=flags)
 
 
 select = Select

--- a/tests/sql/test_selectable.py
+++ b/tests/sql/test_selectable.py
@@ -340,191 +340,208 @@ class SelectTestCase(BaseTestCase):
             )
             return select(table_1.c.x).select_from(join)
 
-        self.assertEqual(
-            self.compile(make_statement(
-                type='INNER'
-            )),
-            'SELECT table_1.x FROM table_1 '
-            'INNER JOIN table_2 ON table_2.y = table_1.x'
-        )
+        def make_statement_select_join(type=None,
+                                       strictness=None,
+                                       distribution=None,
+                                       full=False,
+                                       isouter=False):
+            join = select(table_1).join(
+                table_2,
+                table_2.c.y == table_1.c.x,
+                isouter=isouter,
+                full=full,
+                type=type,
+                strictness=strictness,
+                distribution=distribution
+            )
+            return join
 
-        self.assertEqual(
-            self.compile(make_statement(
-                type='INNER',
-                strictness='all'
-            )),
-            'SELECT table_1.x FROM table_1 '
-            'ALL INNER JOIN table_2 ON table_2.y = table_1.x'
-        )
+        for make_statement in (make_statement, make_statement_select_join):
+            self.assertEqual(
+                self.compile(make_statement(
+                    type='INNER'
+                )),
+                'SELECT table_1.x FROM table_1 '
+                'INNER JOIN table_2 ON table_2.y = table_1.x'
+            )
 
-        self.assertEqual(
-            self.compile(make_statement(
-                type='INNER',
-                strictness='any'
-            )),
-            'SELECT table_1.x FROM table_1 '
-            'ANY INNER JOIN table_2 ON table_2.y = table_1.x'
-        )
+            self.assertEqual(
+                self.compile(make_statement(
+                    type='INNER',
+                    strictness='all'
+                )),
+                'SELECT table_1.x FROM table_1 '
+                'ALL INNER JOIN table_2 ON table_2.y = table_1.x'
+            )
 
-        self.assertEqual(
-            self.compile(make_statement(
-                type='INNER',
-                distribution='global'
-            )),
-            'SELECT table_1.x FROM table_1 '
-            'GLOBAL INNER JOIN table_2 ON table_2.y = table_1.x'
-        )
+            self.assertEqual(
+                self.compile(make_statement(
+                    type='INNER',
+                    strictness='any'
+                )),
+                'SELECT table_1.x FROM table_1 '
+                'ANY INNER JOIN table_2 ON table_2.y = table_1.x'
+            )
 
-        self.assertEqual(
-            self.compile(make_statement(
-                type='INNER',
-                distribution='global',
-                strictness='any'
-            )),
-            'SELECT table_1.x FROM table_1 '
-            'GLOBAL ANY INNER JOIN table_2 ON table_2.y = table_1.x'
-        )
+            self.assertEqual(
+                self.compile(make_statement(
+                    type='INNER',
+                    distribution='global'
+                )),
+                'SELECT table_1.x FROM table_1 '
+                'GLOBAL INNER JOIN table_2 ON table_2.y = table_1.x'
+            )
 
-        self.assertEqual(
-            self.compile(make_statement(
-                type='INNER',
-                distribution='global',
-                strictness='all'
-            )),
-            'SELECT table_1.x FROM table_1 '
-            'GLOBAL ALL INNER JOIN table_2 ON table_2.y = table_1.x'
-        )
+            self.assertEqual(
+                self.compile(make_statement(
+                    type='INNER',
+                    distribution='global',
+                    strictness='any'
+                )),
+                'SELECT table_1.x FROM table_1 '
+                'GLOBAL ANY INNER JOIN table_2 ON table_2.y = table_1.x'
+            )
 
-        self.assertEqual(
-            self.compile(make_statement(
-                type='LEFT OUTER',
-                distribution='global',
-                strictness='all')),
-            'SELECT table_1.x FROM table_1 '
-            'GLOBAL ALL LEFT OUTER JOIN table_2 ON table_2.y = table_1.x'
-        )
+            self.assertEqual(
+                self.compile(make_statement(
+                    type='INNER',
+                    distribution='global',
+                    strictness='all'
+                )),
+                'SELECT table_1.x FROM table_1 '
+                'GLOBAL ALL INNER JOIN table_2 ON table_2.y = table_1.x'
+            )
 
-        self.assertEqual(
-            self.compile(make_statement(
-                type='RIGHT OUTER',
-                distribution='global',
-                strictness='all')),
-            'SELECT table_1.x FROM table_1 '
-            'GLOBAL ALL RIGHT OUTER JOIN table_2 ON table_2.y = table_1.x'
-        )
+            self.assertEqual(
+                self.compile(make_statement(
+                    type='LEFT OUTER',
+                    distribution='global',
+                    strictness='all')),
+                'SELECT table_1.x FROM table_1 '
+                'GLOBAL ALL LEFT OUTER JOIN table_2 ON table_2.y = table_1.x'
+            )
 
-        self.assertEqual(
-            self.compile(make_statement(
-                type='CROSS',
-                distribution='global',
-                strictness='all')),
-            'SELECT table_1.x FROM table_1 '
-            'GLOBAL ALL CROSS JOIN table_2 ON table_2.y = table_1.x'
-        )
+            self.assertEqual(
+                self.compile(make_statement(
+                    type='RIGHT OUTER',
+                    distribution='global',
+                    strictness='all')),
+                'SELECT table_1.x FROM table_1 '
+                'GLOBAL ALL RIGHT OUTER JOIN table_2 ON table_2.y = table_1.x'
+            )
 
-        self.assertEqual(
-            self.compile(make_statement(type='FULL OUTER')),
-            'SELECT table_1.x FROM table_1 '
-            'FULL OUTER JOIN table_2 ON table_2.y = table_1.x'
-        )
+            self.assertEqual(
+                self.compile(make_statement(
+                    type='CROSS',
+                    distribution='global',
+                    strictness='all')),
+                'SELECT table_1.x FROM table_1 '
+                'GLOBAL ALL CROSS JOIN table_2 ON table_2.y = table_1.x'
+            )
 
-        self.assertEqual(
-            self.compile(make_statement(isouter=False,
-                                        full=False)),
-            'SELECT table_1.x FROM table_1 '
-            'INNER JOIN table_2 ON table_2.y = table_1.x'
-        )
+            self.assertEqual(
+                self.compile(make_statement(type='FULL OUTER')),
+                'SELECT table_1.x FROM table_1 '
+                'FULL OUTER JOIN table_2 ON table_2.y = table_1.x'
+            )
 
-        self.assertEqual(
-            self.compile(make_statement(isouter=True,
-                                        full=False)),
-            'SELECT table_1.x FROM table_1 '
-            'LEFT OUTER JOIN table_2 ON table_2.y = table_1.x'
-        )
+            self.assertEqual(
+                self.compile(make_statement(isouter=False,
+                                            full=False)),
+                'SELECT table_1.x FROM table_1 '
+                'INNER JOIN table_2 ON table_2.y = table_1.x'
+            )
 
-        self.assertEqual(
-            self.compile(make_statement(isouter=True,
-                                        full=True)),
-            'SELECT table_1.x FROM table_1 '
-            'FULL OUTER JOIN table_2 ON table_2.y = table_1.x'
-        )
+            self.assertEqual(
+                self.compile(make_statement(isouter=True,
+                                            full=False)),
+                'SELECT table_1.x FROM table_1 '
+                'LEFT OUTER JOIN table_2 ON table_2.y = table_1.x'
+            )
 
-        self.assertEqual(
-            self.compile(make_statement(isouter=False,
-                                        full=True)),
-            'SELECT table_1.x FROM table_1 '
-            'FULL OUTER JOIN table_2 ON table_2.y = table_1.x'
-        )
+            self.assertEqual(
+                self.compile(make_statement(isouter=True,
+                                            full=True)),
+                'SELECT table_1.x FROM table_1 '
+                'FULL OUTER JOIN table_2 ON table_2.y = table_1.x'
+            )
 
-        self.assertEqual(
-            self.compile(make_statement(
-                isouter=False, full=False,
-                type='INNER'
-            )),
-            'SELECT table_1.x FROM table_1 '
-            'INNER JOIN table_2 ON table_2.y = table_1.x'
-        )
+            self.assertEqual(
+                self.compile(make_statement(isouter=False,
+                                            full=True)),
+                'SELECT table_1.x FROM table_1 '
+                'FULL OUTER JOIN table_2 ON table_2.y = table_1.x'
+            )
 
-        self.assertEqual(
-            self.compile(make_statement(
-                isouter=False, full=False,
-                type='LEFT OUTER'
-            )),
-            'SELECT table_1.x FROM table_1 '
-            'LEFT OUTER JOIN table_2 ON table_2.y = table_1.x'
-        )
+            self.assertEqual(
+                self.compile(make_statement(
+                    isouter=False, full=False,
+                    type='INNER'
+                )),
+                'SELECT table_1.x FROM table_1 '
+                'INNER JOIN table_2 ON table_2.y = table_1.x'
+            )
 
-        self.assertEqual(
-            self.compile(make_statement(
-                isouter=False, full=False,
-                type='LEFT', strictness='ALL'
-            )),
-            'SELECT table_1.x FROM table_1 '
-            'ALL LEFT JOIN table_2 ON table_2.y = table_1.x'
-        )
+            self.assertEqual(
+                self.compile(make_statement(
+                    isouter=False, full=False,
+                    type='LEFT OUTER'
+                )),
+                'SELECT table_1.x FROM table_1 '
+                'LEFT OUTER JOIN table_2 ON table_2.y = table_1.x'
+            )
 
-        self.assertEqual(
-            self.compile(make_statement(
-                isouter=False, full=False,
-                type='LEFT', strictness='ANY'
-            )),
-            'SELECT table_1.x FROM table_1 '
-            'ANY LEFT JOIN table_2 ON table_2.y = table_1.x'
-        )
+            self.assertEqual(
+                self.compile(make_statement(
+                    isouter=False, full=False,
+                    type='LEFT', strictness='ALL'
+                )),
+                'SELECT table_1.x FROM table_1 '
+                'ALL LEFT JOIN table_2 ON table_2.y = table_1.x'
+            )
 
-        self.assertEqual(
-            self.compile(make_statement(
-                isouter=False, full=False,
-                type='LEFT', strictness='ANY', distribution='GLOBAL'
-            )),
-            'SELECT table_1.x FROM table_1 '
-            'GLOBAL ANY LEFT JOIN table_2 ON table_2.y = table_1.x'
-        )
+            self.assertEqual(
+                self.compile(make_statement(
+                    isouter=False, full=False,
+                    type='LEFT', strictness='ANY'
+                )),
+                'SELECT table_1.x FROM table_1 '
+                'ANY LEFT JOIN table_2 ON table_2.y = table_1.x'
+            )
 
-        self.assertRaises(
-            CompileError,
-            lambda: self.compile(make_statement(
-                isouter=True, full=False,
-                type='INNER', strictness='ANY', distribution='GLOBAL'
-            )),
-        )
+            self.assertEqual(
+                self.compile(make_statement(
+                    isouter=False, full=False,
+                    type='LEFT', strictness='ANY', distribution='GLOBAL'
+                )),
+                'SELECT table_1.x FROM table_1 '
+                'GLOBAL ANY LEFT JOIN table_2 ON table_2.y = table_1.x'
+            )
 
-        self.assertEqual(
-            self.compile(make_statement(
-                type='FULL OUTER', strictness='ANY', distribution='GLOBAL'
-            )),
-            'SELECT table_1.x FROM table_1 GLOBAL '
-            'ANY FULL OUTER JOIN table_2 ON table_2.y = table_1.x'
-        )
+            self.assertRaises(
+                CompileError,
+                lambda: self.compile(make_statement(
+                    isouter=True, full=False,
+                    type='INNER', strictness='ANY', distribution='GLOBAL'
+                )),
+            )
 
-        self.assertEqual(
-            self.compile(make_statement(
-                isouter=True, full=False,
-                type='CROSS',
-            )),
-            'SELECT table_1.x FROM table_1 '
-            'CROSS JOIN table_2 ON table_2.y = table_1.x'
-        )
+            self.assertEqual(
+                self.compile(make_statement(
+                    type='FULL OUTER', strictness='ANY', distribution='GLOBAL'
+                )),
+                'SELECT table_1.x FROM table_1 GLOBAL '
+                'ANY FULL OUTER JOIN table_2 ON table_2.y = table_1.x'
+            )
+
+            self.assertEqual(
+                self.compile(make_statement(
+                    isouter=True, full=False,
+                    type='CROSS',
+                )),
+                'SELECT table_1.x FROM table_1 '
+                'CROSS JOIN table_2 ON table_2.y = table_1.x'
+            )
 
     def test_join_same_column_name(self):
         table_1 = self._make_table(


### PR DESCRIPTION
We discover than requests like `select(table1).join(table2, table2.id == table1.table2Id).where([...])`
didn't work with clickhouse-sqlalchemy but did work with standard sqlalchemy because `select(table1).join(table2, table2.id == table1.table2Id)` is a `Select` object in sqlalchemy2.

This PR fix this (just changed the return of the `join` method) and add a test to prove the fix works.

The diff in the test is massive because I added a for loop to test both ways to compute the join statement. Let me know if you think there is a better way to write the test

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [x] Run `flake8` and fix issues.
- [x] Run `pytest` no tests failed. See https://clickhouse-sqlalchemy.readthedocs.io/en/latest/development.html.
