### PR TITLE
fix(parsing): change the way to quote db_url to fix the test broken by sqlalchemy 2.0.25

### DIFF
--- a/.github/workflows/sa-versions.yml
+++ b/.github/workflows/sa-versions.yml
@@ -1,5 +1,5 @@
 on: [push, pull_request]
-name: "SQLAlchemy >=2.0.18 versions"
+name: "SQLAlchemy >=2.0.25 versions"
 jobs:
   tests:
     runs-on: ubuntu-20.04
@@ -9,7 +9,7 @@ jobs:
           - "3.12"
         clickhouse-version:
           - 23.8.4.69
-        sa-version: [18, 19, 20, 21, 22]
+        sa-version: [25]
 
     name: ${{ matrix.python-version }} SA=2.0.${{ matrix.sa-version }}
     steps:

--- a/clickhouse_sqlalchemy/drivers/native/base.py
+++ b/clickhouse_sqlalchemy/drivers/native/base.py
@@ -1,5 +1,3 @@
-from urllib.parse import quote
-
 from sqlalchemy.sql.elements import TextClause
 from sqlalchemy.util import asbool
 
@@ -54,10 +52,10 @@ class ClickHouseDialect_native(ClickHouseDialect):
     def create_connect_args(self, url):
         url = url.set(drivername='clickhouse')
         if url.username:
-            url = url.set(username=quote(url.username))
+            url = url.set(username=url.username)
 
         if url.password:
-            url = url.set(password=quote(url.password))
+            url = url.set(password=url.password)
 
         self.engine_reflection = asbool(
             url.query.get('engine_reflection', 'true')

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup(
     packages=find_packages('.', exclude=["tests*"]),
     python_requires='>=3.7, <4',
     install_requires=[
-        'sqlalchemy>=2.0.0,<2.1.0',
+        'sqlalchemy>=2.0.25,<2.1.0',
         'requests',
         'clickhouse-driver>=0.1.2',
         'asynch>=0.2.2',

--- a/tests/drivers/native/test_base.py
+++ b/tests/drivers/native/test_base.py
@@ -50,11 +50,23 @@ class TestConnectArgs(BaseTestCase):
         )
 
     def test_quoting(self):
-        user = quote('us#er')
-        password = quote(' pass#word')
+        user = "us#er"
+        password = 'pass#word'
         part = '{}:{}@host/database'.format(user, password)
+        quote_user = quote(user)
+        quote_password = quote(password)
+        quote_part = '{}:{}@host/database'.format(quote_user, quote_password)
+
+        # test with unquote user and password
         url = make_url('clickhouse+native://' + part)
         connect_args = self.dialect.create_connect_args(url)
         self.assertEqual(
-            str(connect_args[0][0]), 'clickhouse://' + part
+            str(connect_args[0][0]), 'clickhouse://' + quote_part
+        )
+
+        # test with quote user and password
+        url = make_url('clickhouse+native://' + quote_part)
+        connect_args = self.dialect.create_connect_args(url)
+        self.assertEqual(
+            str(connect_args[0][0]), 'clickhouse://' + quote_part
         )

--- a/testsrequire.py
+++ b/testsrequire.py
@@ -1,7 +1,7 @@
 
 tests_require = [
     'pytest',
-    'sqlalchemy>=2.0.0,<2.1.0',
+    'sqlalchemy>=2.0.25,<2.1.0',
     'greenlet>=2.0.1',
     'alembic',
     'requests',


### PR DESCRIPTION
Hello, 

Currently, tests are broken on master because of an update of sqlalchemy. This fix corrects the failing test. 
Note that in the test, I remove the space of the password because it now fails (on purpose) because it is not RFC-1738 compliment.

For context, see 
- https://github.com/sqlalchemy/sqlalchemy/pull/10726
- https://github.com/sqlalchemy/sqlalchemy/issues/10662
- https://github.com/sqlalchemy/sqlalchemy/commit/4438883c9703affa3f441be9a230a5f751905a05


Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [x] Run `flake8` and fix issues.
- [x] Run `pytest` no tests failed. See https://clickhouse-sqlalchemy.readthedocs.io/en/latest/development.html.
