### PR TITLE
fix: fixed required_server_version to v22.6.1 on json type

### DIFF
--- a/tests/types/test_json.py
+++ b/tests/types/test_json.py
@@ -28,7 +28,7 @@ class JSONCompilationTestCase(CompilationTestCase):
     class_name_func=class_name_func
 )
 class JSONTestCase(BaseTestCase):
-    required_server_version = (22, 3, 2)
+    required_server_version = (22, 6, 1)
 
     table = Table(
         'test', BaseTestCase.metadata(),


### PR DESCRIPTION
https://github.com/xzkostyan/clickhouse-sqlalchemy/pull/317


Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [x] Run `flake8` and fix issues.
- [x] Run `pytest` no tests failed. See https://clickhouse-sqlalchemy.readthedocs.io/en/latest/development.html.
