### PR TITLE
fix(compiler): make decimal arguments optional

### DIFF
--- a/clickhouse_sqlalchemy/drivers/compilers/typecompiler.py
+++ b/clickhouse_sqlalchemy/drivers/compilers/typecompiler.py
@@ -82,7 +82,13 @@ class ClickHouseTypeCompiler(compiler.GenericTypeCompiler):
         return 'Float64'
 
     def visit_numeric(self, type_, **kw):
-        return 'Decimal(%s, %s)' % (type_.precision, type_.scale)
+        if type_.precision is None:
+            return "Decimal"
+        elif type_.scale is None:
+            return "Decimal(%(precision)s)" % {"precision": type_.precision}
+        else:
+            return ("Decimal(%(precision)s, %(scale)s)" %
+                    {"precision": type_.precision, "scale": type_.scale})
 
     def visit_boolean(self, type_, **kw):
         return 'Bool'


### PR DESCRIPTION
Makes the scale and precision arguments to Decimal optional, fixing non-floor division.

Prior to this change, `select(column('x') / column('y')` would render SQL casting column y into `Decimal(None, None)`  resulting in 'DB::Exception: Decimal argument precision is invalid'. Now the same query will product a cast simply to `Decimal`, using clickhouse default values for precision and scale.

Implementation taken from official mysql dialect https://github.com/sqlalchemy/sqlalchemy/blob/e44e805506fa71318e23a2bfad733fbbf5a9ee59/lib/sqlalchemy/dialects/mysql/base.py#L2143


Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [x] Run `flake8` and fix issues.
- [x] Run `pytest` no tests failed. See https://clickhouse-sqlalchemy.readthedocs.io/en/latest/development.html.
