### PR TITLE
feat: support uuid for http protocol

### DIFF
--- a/clickhouse_sqlalchemy/drivers/http/escaper.py
+++ b/clickhouse_sqlalchemy/drivers/http/escaper.py
@@ -1,6 +1,7 @@
 from datetime import date, datetime
 from decimal import Decimal
 import enum
+import uuid
 
 
 class Escaper(object):
@@ -49,6 +50,9 @@ class Escaper(object):
     def escape_decimal(self, item):
         return float(item)
 
+    def escape_uuid(self, item):
+        return str(item)
+
     def escape_item(self, item):
         if item is None:
             return 'NULL'
@@ -75,5 +79,7 @@ class Escaper(object):
             ) + "}"
         elif isinstance(item, enum.Enum):
             return self.escape_string(item.name)
+        elif isinstance(item, uuid.UUID):
+            return self.escape_uuid(item)
         else:
             raise Exception("Unsupported object {}".format(item))

--- a/tests/drivers/http/test_escaping.py
+++ b/tests/drivers/http/test_escaping.py
@@ -31,8 +31,8 @@ class EscapingTestCase(HttpSessionTestCase):
         self.assertEqual(e.escape([date(2017, 1, 2)]), "['2017-01-02']")
         self.assertEqual(e.escape(dict(x=10, y=20)), {'x': 10, 'y': 20})
         self.assertEqual(
-            e.escape(uuid.UUID("ef3e3d4b-c782-4993-83fc-894ff0aba8ff")),
-            "ef3e3d4b-c782-4993-83fc-894ff0aba8ff"
+            e.escape([uuid.UUID("ef3e3d4b-c782-4993-83fc-894ff0aba8ff")]),
+            '[ef3e3d4b-c782-4993-83fc-894ff0aba8ff]'
         )
         with self.assertRaises(Exception) as ex:
             e.escape([object()])

--- a/tests/drivers/http/test_escaping.py
+++ b/tests/drivers/http/test_escaping.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 from datetime import date
+import uuid
 
 from sqlalchemy import Column, literal
 
@@ -29,6 +30,10 @@ class EscapingTestCase(HttpSessionTestCase):
         self.assertEqual(e.escape([10.0]), '[10.0]')
         self.assertEqual(e.escape([date(2017, 1, 2)]), "['2017-01-02']")
         self.assertEqual(e.escape(dict(x=10, y=20)), {'x': 10, 'y': 20})
+        self.assertEqual(
+            e.escape(uuid.UUID("ef3e3d4b-c782-4993-83fc-894ff0aba8ff")),
+            "ef3e3d4b-c782-4993-83fc-894ff0aba8ff"
+        )
         with self.assertRaises(Exception) as ex:
             e.escape([object()])
 


### PR DESCRIPTION
The `Escaper.escape` method curently doesn't support `uuid.UUID` but it probably should since the other protocols support sending uuid. This pr adds uuid to the escaper case.

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [x] Run `flake8` and fix issues.
- [x] Run `pytest` no tests failed. See https://clickhouse-sqlalchemy.readthedocs.io/en/latest/development.html.
