### PR TITLE
Add support of streaming insert statement.

### DIFF
--- a/clickhouse_sqlalchemy/sql/__init__.py
+++ b/clickhouse_sqlalchemy/sql/__init__.py
@@ -1,6 +1,6 @@
 
 from .schema import Table, MaterializedView
 from .selectable import Select, select
+from .dml import Insert, insert
 
-
-__all__ = ('Table', 'MaterializedView', 'Select', 'select')
+__all__ = ('Table', 'MaterializedView', 'Select', 'select', 'Insert', 'insert')

--- a/clickhouse_sqlalchemy/sql/dml.py
+++ b/clickhouse_sqlalchemy/sql/dml.py
@@ -1,0 +1,15 @@
+from sqlalchemy.sql.dml import Insert as BaseInsert
+
+__all__ = ('Insert', 'insert')
+
+
+class Insert(BaseInsert):
+    _values_iterator: None
+
+    def values_iterator(self, columns, iterator):
+        self._values_iterator = iterator
+        self._multi_values = ([{column: None for column in columns}],)
+        return self
+
+
+insert = Insert

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -694,6 +694,23 @@ INSERT FROM SELECT statement:
             .from_select(['day', 'value'], select_query)
         )
 
+Streaming insert:
+
+    .. code-block:: python
+        from datetime import datetime
+        from clickhouse_sqlalchemy import sql
+
+        def generator():
+            for i in range(100):
+                yield [datetime.now(), 1, i]
+
+        session.execute(
+            sql.insert(Statistics).values_iterator(
+                [Statistics.date, Statistics.sign, Statistics.grouping],
+                generator()
+            )
+        )
+
 UPDATE and DELETE
 -----------------
 

--- a/tests/sql/test_insert.py
+++ b/tests/sql/test_insert.py
@@ -57,7 +57,6 @@ class InsertTestCase(NativeSessionTestCase):
             self.session.execute(query)
 
             result = list(self.session.execute(select(table.c.x)))
-            print(result)
             self.assertListEqual(result, [('foo',), ('bar',)])
 
     @require_server_version(19, 3, 3)
@@ -76,5 +75,4 @@ class InsertTestCase(NativeSessionTestCase):
             self.session.execute(query)
 
             result = list(self.session.execute(select(table.c.x)))
-            print(result)
             self.assertListEqual(result, [('foo',), ('bar',)])


### PR DESCRIPTION
Clickhouse widely used to work with large amount of data. Finally best way to work with very huge lists is streaming. However, sqlalchemy itself not supports streaming in inserts (only for select queries). But clickhouse_driver supports generators as source for insert queries.

Here is small workaround, that adds support of generators to clickhouse sqlalchemy in native way. I use it on my project to stream big batches of data (1M rows per query). Sure it can be helpful for other clickhouse users.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [x] Run `flake8` and fix issues.
- [x] Run `pytest` no tests failed. See https://clickhouse-sqlalchemy.readthedocs.io/en/latest/development.html.
