### PR TITLE
fix: Support reflect table usage of Alembic v1.15.0+

### DIFF
--- a/clickhouse_sqlalchemy/alembic/comparators.py
+++ b/clickhouse_sqlalchemy/alembic/comparators.py
@@ -4,7 +4,6 @@ from alembic import __version__ as alembic_version
 from alembic.autogenerate import comparators
 from alembic.autogenerate.compare import _compare_columns
 from alembic.operations.ops import ModifyTableOps
-from alembic.util.sqla_compat import _reflect_table as _alembic_reflect_table
 from sqlalchemy import schema as sa_schema
 from sqlalchemy import text
 
@@ -35,9 +34,15 @@ for default_comparator in comparators._registry[('schema', 'default')]:
 
 
 def _reflect_table(inspector, table):
-    if alembic_version >= (1, 11, 0):
+    if alembic_version >= (1, 15, 0):
+        return inspector.reflect_table(table, None)
+    elif alembic_version >= (1, 11, 0) and alembic_version < (1, 15, 0):
+        from alembic.util.sqla_compat import _reflect_table as _alembic_reflect_table
+
         return _alembic_reflect_table(inspector, table)
     else:
+        from alembic.util.sqla_compat import _reflect_table as _alembic_reflect_table
+
         return _alembic_reflect_table(inspector, table, None)
 
 


### PR DESCRIPTION
Just ran into this with `alembic` v1.15.1, which was caused by changes in https://github.com/sqlalchemy/alembic/commit/ab446ab302ffb2884d0d95e2c76650833e6ed14b.

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [ ] Run `flake8` and fix issues.
- [ ] Run `pytest` no tests failed. See https://clickhouse-sqlalchemy.readthedocs.io/en/latest/development.html.