### PR TITLE
Introduce KafkaEngine support

### DIFF
--- a/clickhouse_sqlalchemy/drivers/compilers/ddlcompiler.py
+++ b/clickhouse_sqlalchemy/drivers/compilers/ddlcompiler.py
@@ -170,6 +170,24 @@ class ClickHouseDDLCompiler(compiler.DDLCompiler):
             )
         return text
 
+    def visit_kafka(self, engine):
+        text = f"{engine.name}()"
+        if not engine.settings:
+            return text
+
+        if engine.settings:
+            text += ' SETTINGS '
+            formatted = []
+            for key, value in sorted(engine.settings.items()):
+                if isinstance(value, str):
+                    formatted.append(f"{key} = '{value}'")
+                else:
+                    formatted.append(f"{key} = {value}")
+
+            text += ', '.join(formatted)
+
+        return text
+
     def visit_engine(self, engine):
         engine_params = engine.get_parameters()
         text = engine.name

--- a/clickhouse_sqlalchemy/engines/__init__.py
+++ b/clickhouse_sqlalchemy/engines/__init__.py
@@ -1,4 +1,4 @@
-
+from .kafka import Kafka
 from .mergetree import (
     MergeTree, AggregatingMergeTree, GraphiteMergeTree, CollapsingMergeTree,
     VersionedCollapsingMergeTree, ReplacingMergeTree, SummingMergeTree
@@ -36,5 +36,6 @@ __all__ = (
     Log,
     Memory,
     Null,
-    File
+    File,
+    Kafka
 )

--- a/clickhouse_sqlalchemy/engines/kafka.py
+++ b/clickhouse_sqlalchemy/engines/kafka.py
@@ -1,0 +1,104 @@
+from enum import Enum
+
+from .base import Engine
+
+
+class KafkaFormat(Enum):
+    TabSeparated = "TabSeparated"
+    TabSeparatedRaw = "TabSeparatedRaw"
+    TabSeparatedWithNames = "TabSeparatedWithNames"
+    TabSeparatedWithNamesAndTypes = "TabSeparatedWithNamesAndTypes"
+    TabSeparatedRawWithNames = "TabSeparatedRawWithNames"
+    TabSeparatedRawWithNamesAndTypes = "TabSeparatedRawWithNamesAndTypes"
+    Template = "Template"
+    TemplateIgnoreSpaces = "TemplateIgnoreSpaces"
+    CSV = "CSV"
+    CSVWithNames = "CSVWithNames"
+    CSVWithNamesAndTypes = "CSVWithNamesAndTypes"
+    CustomSeparated = "CustomSeparated"
+    CustomSeparatedWithNames = "CustomSeparatedWithNames"
+    CustomSeparatedWithNamesAndTypes = "CustomSeparatedWithNamesAndTypes"
+    Values = "Values"
+    JSON = "JSON"
+    JSONAsString = "JSONAsString"
+    JSONAsObject = "JSONAsObject"
+    JSONStrings = "JSONStrings"
+    JSONColumns = "JSONColumns"
+    JSONColumnsWithMetadata = "JSONColumnsWithMetadata"
+    JSONCompact = "JSONCompact"
+    JSONCompactColumns = "JSONCompactColumns"
+    JSONEachRow = "JSONEachRow"
+    JSONStringsEachRow = "JSONStringsEachRow"
+    JSONCompactEachRow = "JSONCompactEachRow"
+    JSONCompactEachRowWithNames = "JSONCompactEachRowWithNames"
+    JSONCompactEachRowWithNamesAndTypes = "JSONCompactEachRowWithNamesAndTypes"
+    JSONCompactStringsEachRow = "JSONCompactStringsEachRow"
+    JSONCompactStringsEachRowWithNames = "JSONCompactStringsEachRowWithNames"
+    JSONCompactStringsEachRowWithNamesAndTypes = (
+        "JSONCompactStringsEachRowWithNamesAndTypes"
+    )
+    JSONObjectEachRow = "JSONObjectEachRow"
+    BSONEachRow = "BSONEachRow"
+    TSKV = "TSKV"
+    Protobuf = "Protobuf"
+    ProtobufSingle = "ProtobufSingle"
+    ProtobufList = "ProtobufList"
+    Avro = "Avro"
+    AvroConfluent = "AvroConfluent"
+    Parquet = "Parquet"
+    ParquetMetadata = "ParquetMetadata"
+    Arrow = "Arrow"
+    ArrowStream = "ArrowStream"
+    ORC = "ORC"
+    One = "One"
+    Npy = "Npy"
+    RowBinary = "RowBinary"
+    RowBinaryWithNames = "RowBinaryWithNames"
+    RowBinaryWithNamesAndTypes = "RowBinaryWithNamesAndTypes"
+    RowBinaryWithDefaults = "RowBinaryWithDefaults"
+    Native = "Native"
+    CapnProto = "CapnProto"
+    LineAsString = "LineAsString"
+    Regexp = "Regexp"
+    RawBLOB = "RawBLOB"
+    MsgPack = "MsgPack"
+    MySQLDump = "MySQLDump"
+    DWARF = "DWARF"
+    Form = "Form"
+
+
+class Kafka(Engine):
+    __visit_name__ = "kafka"
+
+    # opting to represent required settings as engine parameters
+    def __init__(
+        self,
+        kafka_broker_list,
+        kafka_topic_list,
+        kafka_group_name,
+        kafka_format,
+        **settings,
+    ):
+        """See
+        https://clickhouse.com/docs/engines/table-engines/integrations/kafka
+        for more information on allowed settings for KafkaEngine tables.
+
+        Args:
+            kafka_broker_list (list[str]): list of brokers
+            kafka_topic_list (list[str]): list of Kafka topics
+            kafka_group_name (str):  a group of Kafka consumers. Reading
+                margins are tracked for each group separately. If you do not
+                want messages to be duplicated in the cluster, use the same
+                group name everywhere.
+            kafka_format (str): message format. Uses the same notation as the
+                SQL FORMAT function, such as JSONEachRow. For more information,
+                see the Formats section
+                https://clickhouse.com/docs/interfaces/formats
+        """
+        settings["kafka_broker_list"] = ",".join(kafka_broker_list)
+        settings["kafka_topic_list"] = ",".join(kafka_topic_list)
+        settings["kafka_group_name"] = kafka_group_name
+        # for validation of allowed formats
+        settings["kafka_format"] = KafkaFormat(kafka_format).value
+        self.settings = settings
+        super().__init__()

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -255,6 +255,7 @@ Currently supported engines:
 * Memory
 * Null
 * File
+* Kafka
 
 Each engine has it's own parameters. Please refer to ClickHouse documentation
 about engines.

--- a/tests/engines/test_compilation.py
+++ b/tests/engines/test_compilation.py
@@ -708,3 +708,33 @@ class TTLTestCase(EngineTestCaseBase):
             '    date + toIntervalDay(1) TO DISK \'hdd\', '
             '    date + toIntervalDay(1) TO VOLUME \'slow\''
         )
+
+
+class KafkaTestCase(EngineTestCaseBase):
+    def test_basic(self):
+        class TestTable(self.base):
+            date = Column(types.Date, primary_key=True)
+            x = Column(types.Int32)
+            y = Column(types.String)
+            version = Column(types.Int32)
+
+            __table_args__ = (
+                engines.Kafka(
+                    kafka_broker_list=["host1:port1", "host2:port2"],
+                    kafka_topic_list=["test_topic"],
+                    kafka_group_name="test_group",
+                    kafka_format="JSONEachRow",
+                ),
+            )
+
+        self.assertEqual(
+            self.compile(CreateTable(TestTable.__table__)),
+            "CREATE TABLE test_table "
+            "(date Date, x Int32, y String, version Int32) "
+            "ENGINE = Kafka() "
+            "SETTINGS "
+            "kafka_broker_list = 'host1:port1,host2:port2', "
+            "kafka_format = 'JSONEachRow', "
+            "kafka_group_name = 'test_group', "
+            "kafka_topic_list = 'test_topic'"
+        )


### PR DESCRIPTION
Adds limited official support for KafkaEngine as requested in [this ticket](https://github.com/xzkostyan/clickhouse-sqlalchemy/issues/156). Although documentation was added for extending `clickhouse-sqlalchemy` with custom engines downstream, it would be beneficial to the community to add first-class support.

For now, this PR adds logic to the `DDLCompiler` in order to generate `CREATE TABLE` statements using the new engine. This is an experimental engine, as stated by the ClickHouse docs. Tables with this engine should also never be read from directly - the query will simply fail, as noted by ClickHouse docs.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [x] Run `flake8` and fix issues.
- [x] Run `pytest` no tests failed. See https://clickhouse-sqlalchemy.readthedocs.io/en/latest/development.html.