### PR TITLE
fix: support asynch 0.2.5+ by using Connection constructor

### DIFF
--- a/clickhouse_sqlalchemy/drivers/asynch/connector.py
+++ b/clickhouse_sqlalchemy/drivers/asynch/connector.py
@@ -146,7 +146,7 @@ class AsyncAdapt_asynch_dbapi:
     def connect(self, *args, **kwargs) -> 'AsyncAdapt_asynch_connection':
         return AsyncAdapt_asynch_connection(
             self,
-            await_only(self.asynch.connect(*args, **kwargs))
+            self.asynch.connection.Connection(*args, **kwargs)
         )
 
 

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup(
         'sqlalchemy>=2.0.0,<2.1.0',
         'requests',
         'clickhouse-driver>=0.1.2',
-        'asynch>=0.2.2,<=0.2.4',
+        'asynch>=0.2.5',
     ],
     # Registering `clickhouse` as dialect.
     entry_points={


### PR DESCRIPTION
<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #374

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [x] Run `flake8` and fix issues.
- [x] Run `pytest` no tests failed. See https://clickhouse-sqlalchemy.readthedocs.io/en/latest/development.html.

## Description

This PR fixes compatibility with asynch 0.2.5+ by replacing the deprecated `asynch.connect()` function with the new `Connection` constructor. Starting from asynch 0.2.5, the API parameters changed and the old `connect` function was removed.

### Changes:
- Updated `clickhouse_sqlalchemy/drivers/asynch/connector.py` to use `self.asynch.connection.Connection(*args, **kwargs)` instead of `asynch.connect(*args, **kwargs)`
- Updated version constraint in `setup.py` from `asynch>=0.2.2,<=0.2.4` to `asynch>=0.2.5` to reflect the minimum required version for the new API