### PR TITLE
Add boolean converter for http driver

### DIFF
--- a/clickhouse_sqlalchemy/drivers/http/transport.py
+++ b/clickhouse_sqlalchemy/drivers/http/transport.py
@@ -47,6 +47,14 @@ def nothing_converter(x):
     return None
 
 
+def bool_converter(x):
+    if x in (1, '1', True, 'true'):
+        return True
+    elif x in (0, '0', False, 'false'):
+        return False
+    return None
+
+
 converters = {
     'Int8': int,
     'UInt8': int,
@@ -70,6 +78,7 @@ converters = {
     'IPv6': IPv6Address,
     'Nullable': nullable_converter,
     'Nothing': nothing_converter,
+    'Bool': bool_converter,
 }
 
 

--- a/tests/drivers/http/test_transport.py
+++ b/tests/drivers/http/test_transport.py
@@ -215,3 +215,23 @@ class TransportCase(HttpSessionTestCase):
 
         rv = self.session.query(*table.c).all()
         self.assertEqual(rv, [(None, )])
+
+    @mock.activate
+    def test_parse_bool(self):
+        mock.add(
+            mock.POST, self.url, status=200,
+            body=(
+                'a\n' +
+                'Bool\n' +
+                '\\N\n' +
+                'true\n'
+            )
+        )
+
+        table = Table(
+            't1', self.metadata(),
+            Column('a', types.Boolean)
+        )
+
+        rv = self.session.query(*table.c).all()
+        self.assertEqual(rv, [(True, )])


### PR DESCRIPTION
The HTTP driver does not support the boolean type.

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [ ] Run `flake8` and fix issues.
- [ ] Run `pytest` no tests failed. See https://clickhouse-sqlalchemy.readthedocs.io/en/latest/development.html.
